### PR TITLE
Reserving 007X GIP number range.

### DIFF
--- a/gips/0070-Evolving-The-Graph-Protocol-Vision-(2024).md
+++ b/gips/0070-Evolving-The-Graph-Protocol-Vision-(2024).md
@@ -1,6 +1,6 @@
 ---
 GIP: "0070"
-Title: Evolving The Graph Protocol
+Title: Evolving The Graph Protocol Vision (2024)
 Authors: Rembrandt Kuipers <rem@edgeandnode.com>
 Created: 2024-09-TBC
 Updated: 2024-09-TBC

--- a/gips/0070-Evolving-The-Graph-Protocol.md
+++ b/gips/0070-Evolving-The-Graph-Protocol.md
@@ -1,0 +1,36 @@
+---
+GIP: "0070"
+Title: Evolving The Graph Protocol
+Authors: Rembrandt Kuipers <rem@edgeandnode.com>
+Created: 2024-09-TBC
+Updated: 2024-09-TBC
+Stage: Reserved
+Discussions-To: TBD
+Category: "Protocol Logic"
+---
+
+This GIP number has been reserved for a series of GIPs currently being drafted.
+
+## Abstract
+
+## Motivation
+
+## Prior Art
+
+## High-Level Description
+
+## Detailed Specification
+
+## Backward Compatibility
+
+## Dependencies
+
+## Risks and Security Considerations
+
+## Validation
+
+## Rationale and Alternatives
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/gips/0071-Reserved.md
+++ b/gips/0071-Reserved.md
@@ -1,0 +1,36 @@
+---
+GIP: "0071"
+Title: Reserved
+Authors: Rembrandt Kuipers <rem@edgeandnode.com>
+Created: 2024-TBD
+Updated: 2024-TBD
+Stage: Reserved
+Discussions-To: TBD
+Category: "Protocol Logic"
+---
+
+This GIP number has been reserved for a series of GIPs currently being drafted.
+
+## Abstract
+
+## Motivation
+
+## Prior Art
+
+## High-Level Description
+
+## Detailed Specification
+
+## Backward Compatibility
+
+## Dependencies
+
+## Risks and Security Considerations
+
+## Validation
+
+## Rationale and Alternatives
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/gips/0072-Reserved.md
+++ b/gips/0072-Reserved.md
@@ -1,0 +1,36 @@
+---
+GIP: "0072"
+Title: Reserved
+Authors: Rembrandt Kuipers <rem@edgeandnode.com>
+Created: 2024-TBD
+Updated: 2024-TBD
+Stage: Reserved
+Discussions-To: TBD
+Category: "Protocol Logic"
+---
+
+This GIP number has been reserved for a series of GIPs currently being drafted.
+
+## Abstract
+
+## Motivation
+
+## Prior Art
+
+## High-Level Description
+
+## Detailed Specification
+
+## Backward Compatibility
+
+## Dependencies
+
+## Risks and Security Considerations
+
+## Validation
+
+## Rationale and Alternatives
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/gips/0073-Reserved.md
+++ b/gips/0073-Reserved.md
@@ -1,0 +1,36 @@
+---
+GIP: "0073"
+Title: Reserved
+Authors: Rembrandt Kuipers <rem@edgeandnode.com>
+Created: 2024-TBD
+Updated: 2024-TBD
+Stage: Reserved
+Discussions-To: TBD
+Category: "Protocol Logic"
+---
+
+This GIP number has been reserved for a series of GIPs currently being drafted.
+
+## Abstract
+
+## Motivation
+
+## Prior Art
+
+## High-Level Description
+
+## Detailed Specification
+
+## Backward Compatibility
+
+## Dependencies
+
+## Risks and Security Considerations
+
+## Validation
+
+## Rationale and Alternatives
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/gips/0074-Reserved.md
+++ b/gips/0074-Reserved.md
@@ -1,0 +1,36 @@
+---
+GIP: "0074"
+Title: Reserved
+Authors: Rembrandt Kuipers <rem@edgeandnode.com>
+Created: 2024-TBD
+Updated: 2024-TBD
+Stage: Reserved
+Discussions-To: TBD
+Category: "Protocol Logic"
+---
+
+This GIP number has been reserved for a series of GIPs currently being drafted.
+
+## Abstract
+
+## Motivation
+
+## Prior Art
+
+## High-Level Description
+
+## Detailed Specification
+
+## Backward Compatibility
+
+## Dependencies
+
+## Risks and Security Considerations
+
+## Validation
+
+## Rationale and Alternatives
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/gips/0075-Reserved.md
+++ b/gips/0075-Reserved.md
@@ -1,0 +1,36 @@
+---
+GIP: "0075"
+Title: Reserved
+Authors: Rembrandt Kuipers <rem@edgeandnode.com>
+Created: 2024-TBD
+Updated: 2024-TBD
+Stage: Reserved
+Discussions-To: TBD
+Category: "Protocol Logic"
+---
+
+This GIP number has been reserved for a series of GIPs currently being drafted.
+
+## Abstract
+
+## Motivation
+
+## Prior Art
+
+## High-Level Description
+
+## Detailed Specification
+
+## Backward Compatibility
+
+## Dependencies
+
+## Risks and Security Considerations
+
+## Validation
+
+## Rationale and Alternatives
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/gips/0076-Reserved.md
+++ b/gips/0076-Reserved.md
@@ -1,0 +1,36 @@
+---
+GIP: "0076"
+Title: Reserved
+Authors: Rembrandt Kuipers <rem@edgeandnode.com>
+Created: 2024-TBD
+Updated: 2024-TBD
+Stage: Reserved
+Discussions-To: TBD
+Category: "Protocol Logic"
+---
+
+This GIP number has been reserved for a series of GIPs currently being drafted.
+
+## Abstract
+
+## Motivation
+
+## Prior Art
+
+## High-Level Description
+
+## Detailed Specification
+
+## Backward Compatibility
+
+## Dependencies
+
+## Risks and Security Considerations
+
+## Validation
+
+## Rationale and Alternatives
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/gips/0077-Reserved.md
+++ b/gips/0077-Reserved.md
@@ -1,0 +1,36 @@
+---
+GIP: "0077"
+Title: Reserved
+Authors: Rembrandt Kuipers <rem@edgeandnode.com>
+Created: 2024-TBD
+Updated: 2024-TBD
+Stage: Reserved
+Discussions-To: TBD
+Category: "Protocol Logic"
+---
+
+This GIP number has been reserved for a series of GIPs currently being drafted.
+
+## Abstract
+
+## Motivation
+
+## Prior Art
+
+## High-Level Description
+
+## Detailed Specification
+
+## Backward Compatibility
+
+## Dependencies
+
+## Risks and Security Considerations
+
+## Validation
+
+## Rationale and Alternatives
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/gips/0078-Reserved.md
+++ b/gips/0078-Reserved.md
@@ -1,0 +1,36 @@
+---
+GIP: "0078"
+Title: Reserved
+Authors: Rembrandt Kuipers <rem@edgeandnode.com>
+Created: 2024-TBD
+Updated: 2024-TBD
+Stage: Reserved
+Discussions-To: TBD
+Category: "Protocol Logic"
+---
+
+This GIP number has been reserved for a series of GIPs currently being drafted.
+
+## Abstract
+
+## Motivation
+
+## Prior Art
+
+## High-Level Description
+
+## Detailed Specification
+
+## Backward Compatibility
+
+## Dependencies
+
+## Risks and Security Considerations
+
+## Validation
+
+## Rationale and Alternatives
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/gips/0079-Reserved.md
+++ b/gips/0079-Reserved.md
@@ -1,0 +1,36 @@
+---
+GIP: "0079"
+Title: Reserved
+Authors: Rembrandt Kuipers <rem@edgeandnode.com>
+Created: 2024-TBD
+Updated: 2024-TBD
+Stage: Reserved
+Discussions-To: TBD
+Category: "Protocol Logic"
+---
+
+This GIP number has been reserved for a series of GIPs currently being drafted.
+
+## Abstract
+
+## Motivation
+
+## Prior Art
+
+## High-Level Description
+
+## Detailed Specification
+
+## Backward Compatibility
+
+## Dependencies
+
+## Risks and Security Considerations
+
+## Validation
+
+## Rationale and Alternatives
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Reserving the 007X GIP range for set of related GIPs that are currently being drafted.

The first GIP in the range (GIP-00700) will introduce the set of GIPs, and following GIPs in the range will provide component details.

This will help readers of GIPs by having this set of related GIPs grouped together. It also helps the drafting process to have a known stable set of GIP numbers.