### PR TITLE
GIP-0079 updates

### DIFF
--- a/gips/0079.md
+++ b/gips/0079.md
@@ -1,11 +1,12 @@
 ---
 GIP: '0079'
 Title: Indexer Rewards Eligibility Oracle
+Created: 2023-10-10
 Authors:
   - Rembrandt Kuipers <rembrandt@edgeandnode.com>
   - Samuel Metcalfe <samuel@edgeandnode.com>
 Stage: Draft
-Discussions-To: TBD
+Discussions-To: <https://forum.thegraph.com/t/gip-0079-indexer-rewards-eligibility-oracle/6734>
 Category: 'Protocol Logic'
 ---
 

--- a/gips/0079.md
+++ b/gips/0079.md
@@ -1,5 +1,5 @@
 ---
-GIP: '0079'
+GIP: "0079"
 Title: Indexer Rewards Eligibility Oracle
 Created: 2023-10-10
 Authors:
@@ -7,12 +7,16 @@ Authors:
   - Samuel Metcalfe <samuel@edgeandnode.com>
 Stage: Draft
 Discussions-To: <https://forum.thegraph.com/t/gip-0079-indexer-rewards-eligibility-oracle/6734>
-Category: 'Protocol Logic'
+Category: "Protocol Logic"
+Depends-On:
+  - "GIP-0086"
 ---
 
 ## Abstract
 
-This GIP proposes the implementation of a Rewards Eligibility Oracle System that enforces minimum service quality requirements for indexers to receive indexing rewards. The system consists of an on-chain Oracle Contract that tracks indexer eligibility and off-chain Oracle Nodes that assess service quality and report eligible indexers to the Contract. This GIP also includes the necessary RewardsManager upgrades to integrate with the Oracle Contract. We anticipate that this mechanism will improve the overall reliability and performance of The Graph network and help the network better compete against other data service providers by aligning indexing incentives with service quality.
+This GIP proposes the implementation of a Rewards Eligibility Oracle System that enforces minimum service quality requirements for indexers to receive indexing rewards. The system consists of an on-chain Oracle Contract that tracks indexer eligibility and off-chain Oracle Nodes that assess service quality and report eligible indexers to the Contract. We anticipate that this mechanism will improve the overall reliability and performance of The Graph network and help the network better compete against other data service providers by aligning indexing incentives with service quality.
+
+Deploying this oracle requires a corresponding upgrade to the Rewards Manager and Subgraph Service, specified in [GIP-0086: Rewards Manager and Subgraph Service Upgrade](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0086.md). Approving this GIP implies deploying both the Oracle Contract and the GIP-0086 upgrade, after which governance configures the upgraded Rewards Manager to use the oracle.
 
 ## Contents
 
@@ -31,6 +35,7 @@ This GIP proposes the implementation of a Rewards Eligibility Oracle System that
   - [Roles and Access Control](#roles-and-access-control)
   - [Configuration Parameters](#configuration-parameters)
 - [Off-chain Logic](#off-chain-logic)
+- [Dependencies](#dependencies)
 - [Backward Compatibility](#backward-compatibility)
 - [Risks](#risks)
 - [Copyright Waiver](#copyright-waiver)
@@ -46,7 +51,7 @@ The Rewards Eligibility Oracle System addresses this by making eligibility for I
 This GIP introduces a service quality enforcement system consisting of two main components:
 
 1. **Oracle Contract**: Tracks indexer eligibility based on service quality assessments from Oracle Nodes
-2. **RewardsManager Integration**: Enforces eligibility checks before distributing indexing rewards
+2. **RewardsManager Integration** ([GIP-0086](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0086.md)): Enforces eligibility checks before distributing indexing rewards
 
 ### System Flow
 
@@ -118,50 +123,13 @@ interface IRewardsEligibilityOracle {
 
 ### RewardsManager Integration
 
-The RewardsManager is upgraded to optionally enforce service quality before distributing rewards. This integration is backward compatible and only activates when an Oracle Contract is configured.
+The Rewards Manager is upgraded to optionally enforce service quality before distributing rewards. The full specification of the Rewards Manager and Subgraph Service upgrade is in [GIP-0086](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0086.md). The integration points relevant to this oracle are:
 
-1. **Optional Integration**: When an Oracle Contract is configured, the RewardsManager checks eligibility before reward distribution.
-2. **Eligibility Verification**: Calls the Oracle Contract's `isAllowed()` function during reward claims.
-3. **Reward Gating**: Only eligible indexers receive rewards; ineligible indexers are denied rewards.
-4. **Backward Compatibility**: When no Oracle Contract is configured, operates exactly as before.
+1. **Optional Integration**: When the Oracle Contract is configured on the Rewards Manager, it checks eligibility before reward distribution. When not configured, the Rewards Manager operates exactly as before.
+2. **Eligibility Verification**: At claim time, the Rewards Manager calls the Oracle Contract's `isEligible()` function. If the indexer is ineligible, rewards are denied and a `RewardsDeniedDueToEligibility` event is emitted.
+3. **Governance Activation**: Governance connects the oracle by calling `setRewardsEligibilityOracle()` on the upgraded Rewards Manager, and can disconnect it at any time by setting the zero address.
 
-#### Service Quality Enforcement
-
-```solidity
-function takeRewards(address _allocationID) external returns (uint256) {
-    // ... existing logic ...
-
-    if (address(rewardsEligibilityOracle) != address(0)) {
-        address indexer = allocations[_allocationID].indexer;
-        if (!rewardsEligibilityOracle.isEligible(indexer)) {
-            emit RewardsDeniedDueToEligibility(indexer, _allocationID);
-            return 0;
-        }
-    }
-
-    // ... continue with reward distribution ...
-}
-```
-
-#### Configuration
-
-```solidity
-function setRewardsEligibilityOracle(address _oracle) external onlyRole(Roles.GOVERNOR) {
-    rewardsEligibilityOracle = IRewardsEligibilityOracle(_oracle);
-    emit RewardsEligibilityOracleSet(_oracle);
-}
-```
-
-#### Events
-
-```solidity
-event RewardsEligibilityOracleSet(address indexed oracle);
-event RewardsDeniedDueToEligibility(address indexed indexer, address indexed allocationID);
-```
-
-#### Interface Requirements
-
-The RewardsManager expects the Oracle Contract to implement:
+The Rewards Manager expects the Oracle Contract to implement:
 
 ```solidity
 interface IRewardsEligibilityOracle {
@@ -196,11 +164,9 @@ Oracle Nodes are expected to regularly update indexer eligibility to ensure the 
 - **ORACLE_ROLE**: Can renew indexer eligibility for rewards via `renewIndexerEligibility()` function
 - **PAUSE_ROLE**: Can pause/unpause contract operations
 
-**RewardsManager Integration:**
+**Rewards Manager** (see [GIP-0086](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0086.md)):
 
 - **GOVERNOR_ROLE**: Can set the RewardsEligibilityOracle address via `setRewardsEligibilityOracle()`
-- **Existing roles**: All current RewardsManager roles and permissions remain unchanged
-- **RewardsEligibilityOracle**: Provides read-only eligibility information when configured
 
 ### Configuration Parameters
 
@@ -246,6 +212,10 @@ The Oracle Node logic for determining indexer service quality includes a conserv
 
    Oracle Nodes incorporate multiple failover mechanisms including automatic RPC provider switching, exponential backoff retry logic, and comprehensive health monitoring. All operations generate detailed logs for operational oversight, while historical eligibility data is preserved for a retention period for internal audit in dated directories. These measures ensure continuous Oracle Node operation.
 
+## Dependencies
+
+- [GIP-0086: Rewards Manager and Subgraph Service Upgrade](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0086.md) — the Rewards Manager must be upgraded (GIP-0086) before the oracle can be connected. Governance activates the oracle by calling `setRewardsEligibilityOracle()` on the upgraded Rewards Manager after both contracts are deployed.
+
 ## Backward Compatibility
 
 The Rewards Eligibility Oracle System is designed to be backward compatible with the existing Graph Protocol:
@@ -257,7 +227,6 @@ The Rewards Eligibility Oracle System is designed to be backward compatible with
 ## Risks
 
 1. **Oracle Node Centralization**: Authorized Oracle Nodes have significant power over reward distribution. This is mitigated by:
-
    - Multiple Oracle Nodes can be authorized
    - Oracle Node actions are transparent and on-chain
    - Oracle update timeout ensures rewards continue if Oracle Nodes fail


### PR DESCRIPTION
The PR is made obsolete by: https://github.com/graphprotocol/graph-improvement-proposals/pull/87

Adding link to forum post and creation date to GIP-0079.

GIP updated to refer to separate GIP-0086 for Rewards Manager upgrade instead of inline specification.