### PR TITLE
GIP-0086: Rewards Manager and Subgraph Service Upgrade

### DIFF
--- a/gips/0086.md
+++ b/gips/0086.md
@@ -1,0 +1,30 @@
+---
+GIP: '0086'
+Title: Rewards Manager and Subgraph Service Upgrade
+Authors: Rembrandt Kuipers <rembrandt@edgeandnode.com>
+Created: 2026-03-04
+Stage: Draft
+Discussions-To: TBD
+Category: 'Protocol Logic'
+Depends-On:
+  - 'GIP-0066'
+  - 'GIP-0068'
+  - 'GIP-0076'
+---
+
+## Abstract
+
+This GIP specifies an upgrade to the Rewards Manager and Subgraph Service contracts. The upgrade makes incremental improvements that enable deployment of the Issuance Allocator ([GIP-0076: Issuance Allocator contract to split issuance across distribution targets](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0076.md)) and Rewards Eligibility Oracle ([GIP-0079: Indexer Rewards Eligibility Oracle](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0079.md)), and prepares the contracts for future activation of rewards reclaiming.
+
+The key improvements are:
+
+1. **Eligibility oracle configuration** — governance can connect an eligibility oracle to the Rewards Manager
+2. **Refined rewards collection** — clearer handling of when rewards are claimed, denied, or deferred
+3. **Rewards reclaiming configuration** — governance can configure addresses to receive undistributable rewards (inactive until configured)
+4. **Improved reward tracking** — better accumulator accounting and new view functions
+
+Full specification to follow.
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/gips/0086.md
+++ b/gips/0086.md
@@ -1,20 +1,20 @@
 ---
-GIP: '0086'
+GIP: "0086"
 Title: Rewards Manager and Subgraph Service Upgrade
 Authors: Rembrandt Kuipers <rembrandt@edgeandnode.com>
-Created: 2026-03-04
+Created: 2026-03-06
 Stage: Draft
 Discussions-To: TBD
-Category: 'Protocol Logic'
+Category: "Protocol Logic"
 Depends-On:
-  - 'GIP-0066'
-  - 'GIP-0068'
-  - 'GIP-0076'
+  - "GIP-0066"
+  - "GIP-0068"
+  - "GIP-0076"
 ---
 
 ## Abstract
 
-This GIP specifies an upgrade to the Rewards Manager and Subgraph Service contracts. The upgrade makes incremental improvements that enable deployment of the Issuance Allocator ([GIP-0076: Issuance Allocator contract to split issuance across distribution targets](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0076.md)) and Rewards Eligibility Oracle ([GIP-0079: Indexer Rewards Eligibility Oracle](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0079.md)), and prepares the contracts for future activation of rewards reclaiming.
+This GIP specifies an upgrade to the Rewards Manager and Subgraph Service contracts. The upgrade does not introduce major new protocol mechanisms but makes incremental improvements that enable deployment of the Issuance Allocator ([GIP-0076: Issuance Allocator contract to split issuance across distribution targets](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0076.md)) and Rewards Eligibility Oracle ([GIP-0079: Indexer Rewards Eligibility Oracle](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0079.md)), and prepare the contracts for future activation of rewards reclaiming, enabling undistributable rewards to be redirected back into the network.
 
 The key improvements are:
 
@@ -23,7 +23,169 @@ The key improvements are:
 3. **Rewards reclaiming configuration** — governance can configure addresses to receive undistributable rewards (inactive until configured)
 4. **Improved reward tracking** — better accumulator accounting and new view functions
 
-Full specification to follow.
+## Contents <!-- omit in toc -->
+
+- [Abstract](#abstract)
+- [Motivation](#motivation)
+- [Prior Art](#prior-art)
+- [High-Level Description](#high-level-description)
+- [Detailed Specification](#detailed-specification)
+  - [1. Eligibility Oracle Configuration](#1-eligibility-oracle-configuration)
+  - [2. Rewards Collection Behaviour](#2-rewards-collection-behaviour)
+  - [3. Rewards Reclaiming Configuration](#3-rewards-reclaiming-configuration)
+  - [4. Improved Reward Tracking](#4-improved-reward-tracking)
+- [Backward Compatibility](#backward-compatibility)
+- [Dependencies](#dependencies)
+- [Risks and Security Considerations](#risks-and-security-considerations)
+- [Copyright Waiver](#copyright-waiver)
+
+## Motivation
+
+Deploying the Issuance Allocator ([GIP-0076](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0076.md)) and Rewards Eligibility Oracle ([GIP-0079](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0079.md)) requires corresponding changes in the Rewards Manager and Subgraph Service. These contracts need to:
+
+- Accept an eligibility oracle reference and enforce eligibility at reward claim time
+- Handle the various situations where rewards cannot be distributed with clear, consistent logic
+- Integrate with the Issuance Allocator for issuance rate sourcing
+- Provide better on-chain visibility into reward outcomes
+
+At a high level, the combined effect of these changes is to: allow integration of the Rewards Eligibility Oracle ([GIP-0079](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0079.md)) so that indexers who fail to meet service quality thresholds can be denied rewards; allow the issuance rate to be sourced from the Issuance Allocator, enabling governance to direct issuance across multiple targets; improve on-chain visibility of reward outcomes so indexers know exactly why a POI presentation did or did not result in rewards; and prepare the infrastructure for redirecting undistributable rewards to designated contracts rather than silently dropping them.
+
+This upgrade also improves how rewards are tracked and reported, benefiting indexers, delegators, and monitoring tools.
+
+## Prior Art
+
+- [GIP-0066: Introducing Graph Horizon](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0066-graph-horizon.md) — the data services protocol framework this upgrade builds on
+- [GIP-0068: Subgraph Service - A subgraph data service in Graph Horizon](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0068-subgraph-service.md) — the Subgraph Service, allocation management, and POI handling
+- [GIP-0076: Issuance Allocator contract to split issuance across distribution targets](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0076.md) — issuance allocation across multiple targets
+- [GIP-0079: Indexer Rewards Eligibility Oracle](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0079.md) — per-indexer eligibility checks for rewards
+
+## High-Level Description
+
+This upgrade refines how rewards flow from issuance to indexers without changing the fundamental reward model. The changes fall into two activation categories:
+
+**Active on deployment** — improvements to rewards accounting, collection handling, and tracking that take effect immediately. These improve how edge cases are handled and provide better visibility into reward outcomes.
+
+**Governance-gated** — capabilities that enable but do not activate changes to protocol issuance or reward flows. The eligibility oracle, issuance allocator integration ([GIP-0076](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0076.md)), and reclaim address configuration all require explicit governance action based on separate approvals before they affect rewards.
+
+## Detailed Specification
+
+### 1. Eligibility Oracle Configuration
+
+Governance can set an optional eligibility oracle on the Rewards Manager. When set, the oracle is consulted each time an indexer claims rewards. If the oracle reports the indexer as ineligible, the claim is denied and no rewards are minted.
+
+**How it works for indexers:**
+
+- When presenting a POI, if an eligibility oracle is configured and reports you as ineligible, you receive zero rewards for that claim
+- A `RewardsDeniedDueToEligibility` event is emitted with the denied amount, providing visibility
+- The oracle can be unset by governance at any time to restore the previous behaviour where all indexers can claim
+- See [GIP-0079](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0079.md) for fail-safe mechanisms built into the oracle proposal
+
+The eligibility check only applies at the moment of claiming. View functions like `getRewards()` do not reflect eligibility, so the estimated reward amount may differ from the actual claim if the indexer becomes ineligible.
+
+Subgraph denial takes precedence: if a subgraph is on the denylist, the eligibility check is not performed.
+
+### 2. Rewards Collection Behaviour
+
+The upgrade refines how the Subgraph Service handles POI presentation, making the logic clearer and closing some edge cases. When an indexer presents a POI, one of three outcomes occurs:
+
+#### Claim — rewards distributed normally
+
+When conditions are met (valid POI, allocation old enough, subgraph not denied, indexer eligible), rewards are calculated and minted. The allocation's reward tracking is updated. This is the normal path that applies to the majority of POI presentations.
+
+#### Deny — rewards forfeited
+
+When a POI cannot result in a valid reward claim, the rewards are forfeited and the allocation's tracking is updated so those rewards cannot be claimed later. This applies when:
+
+- **Stale POI**: The time since the last POI presentation exceeds the staleness threshold. Indexers are expected to present POIs regularly; stale allocations do not earn rewards.
+- **Zero POI**: A POI of `bytes32(0)` is submitted. This allows indexers to keep an allocation from going stale when no valid POI is available yet; pending rewards are forfeited in exchange.
+- **Ineligible indexer**: The eligibility oracle (if configured) reports the indexer as ineligible.
+- **Allocation close**: When an allocation is closed, any uncollected rewards are forfeited rather than remaining locked.
+
+With reclaim addresses configured (see section 3), forfeited rewards can be redirected to a designated contract instead of being dropped. This enables reclaimed rewards to be redirected back into the network, potentially by funding services that improve network health or increase its value to users.
+
+#### Defer — rewards preserved for later
+
+In some situations, rewards should not be claimed yet but should not be forfeited either. The allocation's tracking is left unchanged, preserving the rewards for a future claim:
+
+- **Allocation too young**: An allocation created in the current epoch cannot claim rewards yet. Rewards are preserved until the next epoch.
+- **Subgraph denied**: If a subgraph is currently on the denylist, existing uncollected rewards are preserved. When the subgraph is later removed from the denylist, those rewards become claimable. Previously, presenting a POI for a denied subgraph still advanced the allocation's reward snapshot, permanently dropping any pre-denial rewards; now the snapshot is left unchanged so those rewards survive the denial period. (New rewards that would have accrued during the denial period are not accumulated — see section 4.)
+
+#### POIPresented event
+
+Every POI presentation emits a `POIPresented` event that includes the outcome (claim, deny, or defer) and the reward amount. This provides on-chain visibility that was previously unavailable — indexers and monitoring tools can see exactly why a given POI presentation did or did not result in rewards.
+
+### 3. Rewards Reclaiming Configuration
+
+Currently, when rewards cannot be distributed, they are silently dropped (never minted). This upgrade adds the ability for governance to configure addresses where undistributable rewards are sent instead.
+
+**Per-condition addresses**: Governance can set a specific address for each type of denial (e.g., stale POI, ineligible indexer, denied subgraph). This allows different handling for different situations.
+
+**Default address**: A fallback address that receives rewards for any condition without a specific address configured.
+
+**Resolution**: When rewards are forfeited, the system checks for a condition-specific address first, then the default address. If neither is configured, rewards are dropped as they are today.
+
+**Not activated by this GIP**: This upgrade enables the reclaim configuration capability, but activation (actually setting reclaim addresses) is a separate governance decision. Until addresses are configured, forfeited rewards continue to be dropped as they are today.
+
+### 4. Improved Reward Tracking
+
+#### Accumulator improvements
+
+The reward accumulators that track how rewards flow from issuance to subgraphs to allocations are refined:
+
+- **Denied subgraphs**: When a subgraph is placed on the denylist, its accumulators are frozen. Issuance that would have flowed to the denied subgraph no longer accumulates there. Previously, rewards continued accumulating during denial periods but could never be claimed, creating a permanent gap between issued and distributed tokens. Pre-denial uncollected rewards are preserved and become claimable if the subgraph is later un-denied.
+
+- **Zero global signal**: Periods when there is no curation signal across the network are now detected. Issuance during these periods is tracked separately rather than silently lost.
+
+- **Below-minimum signal**: Subgraphs with curation signal below the minimum threshold are tracked. Rewards that would flow to these subgraphs are identified rather than silently excluded.
+
+- **No allocations**: When a subgraph has curation signal but no indexer allocations, rewards that accumulate at the subgraph level with no recipient are now tracked.
+
+#### New view functions
+
+| Function                         | Description                                                                                     |
+| -------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `getAllocatedIssuancePerBlock()` | Effective issuance rate — from the Issuance Allocator if configured, otherwise the legacy value |
+| `getRawIssuancePerBlock()`       | The legacy issuance storage value, for debugging allocator configuration                        |
+| `getRewardsEligibilityOracle()`  | Current eligibility oracle address (zero if not configured)                                     |
+| `getReclaimAddress(condition)`   | Reclaim address for a specific condition (zero if not configured)                               |
+| `getDefaultReclaimAddress()`     | Default reclaim address (zero if not configured)                                                |
+
+#### Changes to existing view functions
+
+- `getAccRewardsForSubgraph()` and `getAccRewardsPerAllocatedToken()` now reflect accumulator freezing for non-claimable subgraphs. Previously these values always increased; they now freeze when the subgraph is denied, below minimum signal, or has no allocations.
+
+- `getRewards()` returns a frozen value for allocations on non-claimable subgraphs. Note that eligibility is not reflected in this view — it is only checked at actual claim time.
+
+## Backward Compatibility
+
+The upgrade improves rewards accounting and collection handling, which takes effect on deployment. These changes refine how edge cases are handled — for example, denied subgraphs now freeze accumulators rather than accumulating unclaimable rewards.
+
+Features that affect protocol issuance or reward flows — the eligibility oracle, issuance allocator, and reclaim addresses — are enabled but not activated. They require separate governance action and do not change rewards behaviour until configured.
+
+Callers of view functions that rely on accumulators always increasing should be aware that accumulators now freeze for non-claimable subgraphs.
+
+## Dependencies
+
+- [GIP-0076: Issuance Allocator contract to split issuance across distribution targets](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0076.md) — the Rewards Manager sources its issuance rate from the allocator when configured
+
+**Related:**
+
+- [GIP-0079: Indexer Rewards Eligibility Oracle](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0079.md) — the oracle contract that the Rewards Manager consults for eligibility checks. The eligibility oracle integration is governance-gated and does not require GIP-0079 to be deployed for GIP-0086 to be deployed.
+
+## Risks and Security Considerations
+
+1. **Oracle availability**: If the eligibility oracle reverts or becomes unavailable, reward claims will revert for all indexers. The oracle includes a timeout mechanism ([GIP-0079](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0079.md)) that makes all indexers eligible if the oracle is not updated within a configurable period, providing a safety fallback.
+
+2. **Oracle misconfiguration**: Inappropriate configuration parameters on the oracle — such as overly strict thresholds or incorrect freshness windows — could cause it to deny eligibility more broadly than intended. Because eligibility is evaluated at claim time, the impact might not be apparent until indexers attempt to collect. Mitigations:
+   - The oracle's built-in **timeout mechanism** ([GIP-0079](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0079.md)) ensures that if oracle data becomes stale, all subgraphs are treated as eligible, so a failure to update is self-correcting.
+   - The oracle can be **unset by governance** (set to the zero address) to bypass it entirely and restore previous behaviour immediately.
+   - Once corrected, previously denied rewards are not lost — accumulators resume from their frozen snapshots, so indexers collect the full amount they would have earned.
+
+3. **Rewards lost to transient ineligibility**: Eligibility is evaluated at claim time. An indexer who claims during a brief period of ineligibility forfeits those rewards permanently, even though waiting and claiming later (after regaining eligibility) would have preserved them. An eligibility dashboard is provided so indexers can monitor their status before claiming, and additional operational tooling is under consideration.
+
+4. **Broad ineligibility event**: A configuration change or systemic issue could cause many indexers to become ineligible simultaneously. This is mitigated by initially setting very relaxed eligibility criteria, the eligibility dashboard, proactive community communication, and direct assistance to potentially impacted indexers to help them resolve service issues before stricter thresholds are applied.
+
+5. **Accumulator view changes**: External systems reading accumulator values that expect them to always increase will see frozen values for non-claimable subgraphs. This is correct behaviour but might require updates to monitoring or analytics tools.
 
 ## Copyright Waiver
 


### PR DESCRIPTION
The PR is made obsolete by: https://github.com/graphprotocol/graph-improvement-proposals/pull/87

This GIP specifies an upgrade to the Rewards Manager and Subgraph Service contracts.