### PR TITLE
GIP-0088: Issuance Allocator Deployment and Indexing Payments Configuration

### DIFF
--- a/gips/0088.md
+++ b/gips/0088.md
@@ -1,0 +1,29 @@
+---
+GIP: '0088'
+Title: Issuance Allocator Deployment and Indexing Payments Configuration
+Authors: Rembrandt Kuipers <rembrandt@edgeandnode.com>
+Created: 2026-03-05
+Stage: Draft
+Discussions-To: TBD
+Category: 'Protocol Logic'
+Depends-On:
+  - 'GIP-0076'
+  - 'GIP-0086'
+  - 'GIP-0087'
+---
+
+## Abstract
+
+This GIP specifies the deployment and configuration of the Issuance Allocator ([GIP-0076: Issuance Allocator contract to split issuance across distribution targets](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0076.md)), connecting it to the upgraded Rewards Manager ([GIP-0086: Rewards Manager and Subgraph Service Upgrade](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0086.md)) and establishing an issuance allocation for the Recurring Agreement Manager ([GIP-0087: On-Chain Indexing Agreements](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0087.md)).
+
+The Issuance Allocator is a governance-controlled contract that manages how token issuance is distributed across protocol components. This GIP covers three sequential steps:
+
+1. **Deploy the Issuance Allocator** — deploy and configure the contract, replicating the current issuance rate
+2. **Connect the Rewards Manager** — configure the upgraded Rewards Manager to source its issuance rate from the allocator
+3. **Allocate issuance to the Recurring Agreement Manager** — add the agreement manager as an issuance target, enabling protocol-funded indexing agreements
+
+Full specification to follow.
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/gips/0088.md
+++ b/gips/0088.md
@@ -1,15 +1,15 @@
 ---
-GIP: '0088'
+GIP: "0088"
 Title: Issuance Allocator Deployment and Indexing Payments Configuration
 Authors: Rembrandt Kuipers <rembrandt@edgeandnode.com>
-Created: 2026-03-05
+Created: 2026-03-06
 Stage: Draft
 Discussions-To: TBD
-Category: 'Protocol Logic'
+Category: "Protocol Logic"
 Depends-On:
-  - 'GIP-0076'
-  - 'GIP-0086'
-  - 'GIP-0087'
+  - "GIP-0076"
+  - "GIP-0086"
+  - "GIP-0087"
 ---
 
 ## Abstract
@@ -22,7 +22,99 @@ The Issuance Allocator is a governance-controlled contract that manages how toke
 2. **Connect the Rewards Manager** — configure the upgraded Rewards Manager to source its issuance rate from the allocator
 3. **Allocate issuance to the Recurring Agreement Manager** — add the agreement manager as an issuance target, enabling protocol-funded indexing agreements
 
-Full specification to follow.
+## Contents <!-- omit in toc -->
+
+- [Abstract](#abstract)
+- [Motivation](#motivation)
+- [Prior Art](#prior-art)
+- [High-Level Description](#high-level-description)
+- [Detailed Specification](#detailed-specification)
+  - [1. Issuance Allocator Deployment](#1-issuance-allocator-deployment)
+  - [2. Rewards Manager Integration](#2-rewards-manager-integration)
+  - [3. Recurring Agreement Manager Allocation](#3-recurring-agreement-manager-allocation)
+  - [4. Default Target Safety Net](#4-default-target-safety-net)
+- [Backward Compatibility](#backward-compatibility)
+- [Dependencies](#dependencies)
+- [Risks and Security Considerations](#risks-and-security-considerations)
+- [Copyright Waiver](#copyright-waiver)
+
+## Motivation
+
+The Issuance Allocator ([GIP-0076](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0076.md)) enables the protocol to split token issuance across multiple targets — today all issuance goes to the Rewards Manager for indexer rewards, but the protocol needs to also fund indexing agreements through the Recurring Agreement Manager ([GIP-0087](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0087.md)).
+
+Without the allocator, the Recurring Agreement Manager cannot receive minted GRT from issuance and protocol-funded indexing agreements cannot operate.
+
+## Prior Art
+
+- [GIP-0076: Issuance Allocator contract to split issuance across distribution targets](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0076.md) — the contract being deployed
+- [GIP-0086: Rewards Manager and Subgraph Service Upgrade](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0086.md) — the Rewards Manager upgrade that adds `setIssuanceAllocator()` integration
+- [GIP-0087: On-Chain Indexing Agreements](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0087.md) — the Recurring Agreement Manager that will receive issuance
+
+## High-Level Description
+
+Today, the Rewards Manager mints GRT directly based on an issuance rate configured in its own storage. The Issuance Allocator replaces this with a governance-managed allocation system where the total issuance rate is split across targets.
+
+**Phase 1 — Deploy and replicate**: The Issuance Allocator is deployed with the same issuance rate the Rewards Manager currently uses. The Rewards Manager is assigned 100% of issuance as a self-minting target (it continues to mint its own tokens). At this point, nothing changes for indexers or delegators — the same amount of GRT is issued at the same rate.
+
+**Phase 2 — Connect**: The upgraded Rewards Manager is configured to source its issuance rate from the allocator instead of its own storage. The allocator is granted the minter role on GraphToken. The Rewards Manager still receives 100% of issuance and continues to self-mint. There is no change in issuance behaviour.
+
+**Phase 3 — Split**: Governance adds the Recurring Agreement Manager as a new issuance target, initially allocating 6 GRT per block (~5% of issuance) to fund indexing agreements. The Rewards Manager's allocation is reduced accordingly. The allocator mints GRT directly to the agreement manager at the configured rate. The total issuance rate remains unchanged — it is split between two targets rather than going entirely to one.
+
+## Detailed Specification
+
+### 1. Issuance Allocator Deployment
+
+The Issuance Allocator ([GIP-0076](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0076.md)) is deployed as a new contract under governance control. It is configured to replicate the current issuance rate from the Rewards Manager, with the Rewards Manager as the sole target receiving 100% of issuance.
+
+The Rewards Manager is a **self-minting** target — the allocator tracks its allocation but the Rewards Manager continues to mint tokens itself. This means the allocator can be deployed and configured without any change to how issuance works. The deployment is a no-op from the perspective of indexers, delegators, and the broader protocol.
+
+### 2. Rewards Manager Integration
+
+Governance connects the upgraded Rewards Manager ([GIP-0086](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0086.md)) to the allocator. From this point, the Rewards Manager sources its issuance rate from the allocator rather than its own storage. The allocator is also granted the minter role on GraphToken, which it needs to mint tokens directly to future allocator-minting targets.
+
+At this stage the Rewards Manager still receives 100% of issuance and continues to self-mint. There is no change in issuance behaviour.
+
+### 3. Recurring Agreement Manager Allocation
+
+Governance adds the Recurring Agreement Manager ([GIP-0087](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0087.md)) as an **allocator-minting** target — the allocator calculates and mints GRT directly to it. The Rewards Manager's self-minting allocation is reduced by the corresponding amount.
+
+**Proposed initial allocation: 6 GRT per block (~5% of current issuance).** Based on current GRT price and demand forecasts, this is expected to comfortably cover what is initially required to begin migrating indexing off the upgrade indexer. The full cost of indexing has been estimated at approximately $130k/month, which at current prices would require roughly 10% of issuance. The initial 5% allocation provides headroom for the early ramp-up period while keeping the impact on staking rewards modest.
+
+This allocation may need to increase — potentially to ~12 GRT per block (~10% of issuance) — as agreement volume grows. The exact trajectory depends on several highly variable factors: GRT price, the pace of migration from the upgrade indexer, the escrow cycle (which creates an early spike in demand to fill buffers that subsequently settles), and evolving requirements around deployment coverage and replication.
+
+**Future self-balancing**: This initial deployment uses a fixed governance-configured allocation. We intend to replace this with a self-balancing mechanism that adjusts the allocation to meet demand without ongoing governance intervention. Gaining operational experience with the fixed allocation will inform the design of that mechanism. The goal is for the protocol to maintain balanced operation — avoiding both excess accumulation of unused GRT and underfunding — without requiring regular governance action.
+
+The total issuance rate does not change — it is redistributed. With 6 GRT per block allocated to the agreement manager, the Rewards Manager's self-minting allocation decreases from ~120.73 to ~114.73 GRT per block.
+
+The allocator maintains the invariant that the sum of all target allocations equals `issuancePerBlock`. Governance cannot over-allocate — the available budget for a new target is limited to the currently unallocated amount (held by the default target).
+
+### 4. Default Target Safety Net
+
+A DirectAllocation contract under governance control is set as the allocator's default target during deployment. The default target is intended to receive no issuance under normal operation — all issuance should be fully allocated to named targets (Rewards Manager, Recurring Agreement Manager).
+
+However, if a future configuration change is not made atomically (e.g., removing a target before reassigning its allocation), the default target captures the temporarily unallocated issuance rather than leaving it unminted. Only the governance multisig can withdraw from the DirectAllocation. It is intended to remain unused but provides a safety net against accounting gaps during reconfiguration.
+
+## Backward Compatibility
+
+This deployment does not change the total issuance rate or the reward model. During phases 1 and 2, indexers and delegators see no change — the same GRT is issued at the same rate through the same Rewards Manager.
+
+When the agreement manager allocation is configured (phase 3), the Rewards Manager's allocation decreases by the amount redirected to agreements. Indexer rewards from issuance decrease proportionally. This is an intentional policy change — governance is directing a portion of issuance to fund indexing agreements rather than pure staking rewards.
+
+## Dependencies
+
+- [GIP-0076: Issuance Allocator contract to split issuance across distribution targets](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0076.md) — the contract specification
+- [GIP-0086: Rewards Manager and Subgraph Service Upgrade](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0086.md) — the Rewards Manager must be upgraded before integration
+- [GIP-0087: On-Chain Indexing Agreements](https://github.com/graphprotocol/graph-improvement-proposals/blob/main/gips/0087.md) — the Recurring Agreement Manager must be deployed before allocation
+
+## Risks and Security Considerations
+
+1. **Issuance rate mismatch during migration**: If the rate set on the allocator does not exactly match the Rewards Manager's current rate, there will be a discontinuity in issuance. Mitigation: the deployment procedure reads the rate directly from the Rewards Manager and verifies they match before governance transfer.
+
+2. **Deployment sequencing**: The deployment involves multiple contracts and configuration steps that must be executed in the correct order — deploying the allocator, verifying configuration, granting the minter role, and connecting the Rewards Manager. Incorrect sequencing could lead to misconfigured minting or mismatched issuance rates. Mitigation: a detailed deployment procedure with verification steps at each stage.
+
+3. **Allocation rebalancing impact**: Redirecting issuance from the Rewards Manager to the agreement manager reduces staking rewards while increasing agreement-based payments — both flow to indexers, but through different mechanisms with different distribution characteristics. If the shift is too large relative to agreement volume, excess GRT may accumulate in the agreement manager's escrow rather than reaching indexers promptly. Mitigation: governance controls the allocation rate and can adjust it incrementally. The allocation change is transparent and subject to governance approval.
+
+4. **Pause propagation**: Pausing the Issuance Allocator stops allocator-minting (tokens are not minted to the agreement manager) but self-minting targets like the Rewards Manager continue to track issuance via accumulation. When unpaused, the allocator applies current rates retroactively to the undistributed period. Mitigation: pause functionality is controlled by a dedicated pause guardian, and the accumulation model ensures accounting integrity across pause/unpause transitions.
 
 ## Copyright Waiver
 


### PR DESCRIPTION
The PR is made obsolete by: https://github.com/graphprotocol/graph-improvement-proposals/pull/87

This GIP specifies the deployment and configuration of the Issuance Allocator, connecting it to the upgraded Rewards Manager and establishing an issuance allocation for the Recurring Agreement Manager.