### PR TITLE
GIPs 0076, 0086, 0087, 0088, and 0079 updates for Rewards Eligibility Oracle and Indexing Payments

### DIFF
--- a/gips/0076.md
+++ b/gips/0076.md
@@ -1,36 +1,206 @@
 ---
-GIP: "0076"
-Title: Implement upgraded Curation and distribute issuance based on locked GRT
+GIP: '0076'
+Title: Issuance Allocator contract to split issuance across distribution targets
 Authors: Rembrandt Kuipers <rembrandt@edgeandnode.com>
 Stage: Draft
 Discussions-To: TBD
-Category: "Protocol Logic"
-Depends-On: "GIP-0070"
+Category: 'Protocol Logic'
+Depends-On:
+  - 'GIP-0070'
 ---
-
-This GIP number has been reserved.
-
-This GIP is being drafted and all content is subject to change.
 
 ## Abstract
 
-## Motivation
+This GIP introduces a simple Issuance Allocator contract. In this iteration the Issuance Allocator operates based on fixed proportions, while future iterations can introduce self-balancing of issuance as outlined in GIP-0070. No change to issuance distribution is proposed in this GIP. This GIP also specifies the Rewards Manager upgrades that integrate with the Issuance Allocator mechanism.
+
+## Introduction
+
+The Graph community has shown strong support for upgrading network economics as outlined in [GIP-0070](0070.md). This proposal introduces a flexible issuance allocation mechanism through an "Issuance Allocator" contract that enables governance to configure how issuance is distributed across multiple targets.
+
+This implementation takes an iterative approach to pursuing the long-term vision, creating a design that allows for new mechanisms to be piloted in parallel to existing distribution by the Rewards Manager before being integrated into the main issuance stream.
+
+The Issuance Allocator contract design is made in combination with the Rewards Manager upgrade specified in this GIP.
+
+## Contents <!-- omit in toc -->
+
+<!-- ToC is automatically generated; manual updates are likely to be lost. -->
+
+- [Abstract](#abstract)
+- [Introduction](#introduction)
+- [Prior Art](#prior-art)
+- [High-Level Description](#high-level-description)
+  - [Architecture Overview](#architecture-overview)
+- [Detailed Specification](#detailed-specification)
+  - [1. Issuance Allocator Contract](#1-issuance-allocator-contract)
+  - [2. Direct Allocation](#2-direct-allocation)
+  - [3. Rewards Manager Integration](#3-rewards-manager-integration)
+  - [4. Governance and Monitoring](#4-governance-and-monitoring)
+- [Alternatives](#alternatives)
+- [Copyright Waiver](#copyright-waiver)
 
 ## Prior Art
 
+This proposal builds on [GIP-0070](0070.md), which outlines a long-term vision for evolving The Graph Protocol economics.
+
 ## High-Level Description
+
+The implementation creates a flexible issuance allocation system with three main components:
+
+1. **Issuance Allocator Contract**: A governance-controlled contract that can split issuance between multiple configurable targets with adjustable allocation percentages.
+
+2. **Target Integration Framework**: Supports both self-minting targets (like the existing Rewards Manager) and allocator-minting targets (like Direct Allocation contracts).
+
+3. **Integration with existing Rewards Manager**: The Rewards Manager can optionally source its issuance rate from the IssuanceAllocator (detailed in section 3).
+
+### Architecture Overview
+
+The following diagram illustrates how the components interact using an illustrative example of a Pilot Allocation (not proposed in this GIP):
+
+```mermaid
+flowchart TB
+  Governance["🏛️ Governance<br/>(The Graph Council)"]
+  IssuanceAllocator["📊 Issuance Allocator"]
+  RewardsManager["💰 Rewards Manager<br/>(Self-Minting)"]
+  PilotAllocation["🧪 Pilot Allocation<br/>(Illustrative)<br/>(Allocator-Minting)"]
+
+  %% Governance and allocation flows
+  Governance -->|"Sets allocation<br/>percentages"| IssuanceAllocator
+  IssuanceAllocator -->|"Provides calculated<br/>issuance rate"| RewardsManager
+  IssuanceAllocator -->|"Mints tokens<br/>directly"| PilotAllocation
+
+  %% Styling
+  classDef allocator fill:#6F4CFF,stroke:#0C0A1D,stroke-width:2px,color:#0C0A1D
+  classDef allocation fill:#4BCA81,stroke:#0C0A1D,stroke-width:2px,color:#0C0A1D
+
+  class IssuanceAllocator allocator
+  class RewardsManager,PilotAllocation allocation
+```
+
+1. Governance sets allocation percentages in the Issuance Allocator.
+2. The Issuance Allocator calculates issuance for all targets.
+3. For allocator-minting targets (e.g., a Direct Allocation instance for a pilot), the Issuance Allocator mints tokens directly.
+4. For self-minting targets (Rewards Manager), the Issuance Allocator provides the issuance rate, and the target mints tokens itself.
+5. Rewards Manager integration details are specified in section 3.
 
 ## Detailed Specification
 
-## Backward Compatibility
+### 1. Issuance Allocator Contract
 
-## Dependencies
+Note: This allocation mechanism is distinct from subgraph allocations. The Issuance Allocator operates at the protocol level to manage overall token issuance, whereas subgraph allocations relate to indexer-specific allocations for individual subgraphs.
 
-## Risks and Security Considerations
+**The Mechanism**: A new top-level smart contract that provides flexible issuance allocation:
 
-## Validation
+- Maintains existing total issuance per block rate
+- Supports multiple configurable targets with governance-controlled allocation percentages
+- Can add, remove, or adjust target allocations through governance
+- Functions to set allocation percentages and distribute issuance to configured targets
 
-## Rationale and Alternatives
+No specific new targets are proposed. The mechanism supports any number of targets with governance-approved allocation percentages. In this iteration it can simply set the Rewards Manager's proportion; future GIPs may configure additional targets.
+
+#### 1.1 Issuance Allocator Interface
+
+The Issuance Allocator contract is responsible for allocating token issuance to different components of the protocol. It calculates issuance for all targets based on their configured proportions and handles minting for allocator-minting targets.
+
+The contract distinguishes between two types of targets:
+
+1. **Self-Minting Targets**: These are contracts that have their own minting authority (like the existing Rewards Manager). The Issuance Allocator calculates issuance for these targets but does not mint tokens directly to them. Instead, these contracts call `getTargetIssuancePerBlock()` to determine their issuance amount and mint tokens themselves.
+
+2. **Allocator-Minting Targets**: These are contracts that cannot mint tokens themselves. The Issuance Allocator calculates issuance for these targets and mints tokens directly to them.
+
+The self-minting feature is intended only for backwards compatibility with the existing Rewards Manager. New targets are expected to be allocator-minting, as this provides more robust control over token issuance.
+
+#### 1.2 Pause and Accumulation System
+
+The IssuanceAllocator includes a pause and accumulation system for operational safety:
+
+- **When paused**: Distribution stops for allocator-minting targets, but issuance accumulates and will be distributed when unpaused
+- **Self-minting targets**: Continue to operate (for backward compatibility with Rewards Manager)
+- **Governance functions**: Remain available during pause for configuration changes
+- **Recovery**: Accumulated issuance is distributed proportionally when unpaused or via manual `distributePendingIssuance()`
+
+This system enables rapid response to operational issues while preserving issuance integrity.
+
+#### 1.3 Roles and Access Control
+
+The IssuanceAllocator uses role-based access control:
+
+- **GOVERNOR_ROLE**: Can set issuance rates and manage target allocations
+- **PAUSE_ROLE**: Can pause/unpause contract operations for emergency response
+
+### 2. Direct Allocation
+
+A generic Direct Allocation contract implements the `IIssuanceTarget` interface and serves as an allocator-minting target. When configured, the Issuance Allocator mints tokens directly to this contract, and an authorized operator can send them to designated addresses.
+
+The contract is pausable, and when paused, tokens cannot be sent. Future GIPs may propose specific Direct Allocation instances for various purposes such as pilot programs or other network initiatives.
+
+### 3. Rewards Manager Integration
+
+The Rewards Manager is upgraded to optionally integrate with the IssuanceAllocator. Changes are minimal and backwards compatible.
+
+#### 3.1 Issuance Configuration
+
+The Rewards Manager can optionally source its issuance rate from an IssuanceAllocator. If the issuanceAllocator address is set, it queries the allocator for its self-minting issuance rate; otherwise it uses the existing internal issuancePerBlock.
+
+```solidity
+function getRewardsIssuancePerBlock() public view returns (uint256) {
+    if (issuanceAllocator != address(0)) {
+        return IIssuanceAllocator(issuanceAllocator).getTargetIssuancePerBlock(address(this)).selfIssuancePerBlock;
+    }
+    return issuancePerBlock;
+}
+```
+
+Governance function to set the IssuanceAllocator address (only governor):
+
+```solidity
+function setIssuanceAllocator(address _allocator) external onlyRole(Roles.GOVERNOR) {
+    issuanceAllocator = _allocator;
+}
+```
+
+#### 3.2 Allocation-Change Hook
+
+To maintain correct accounting when allocations change, Rewards Manager implements `IIssuanceTarget.beforeIssuanceAllocationChange()`, which the IssuanceAllocator calls before modifying allocations to update internal state.
+
+#### 3.3 Roles and Access Control
+
+- **GOVERNOR_ROLE**: Can set the IssuanceAllocator address
+- **IssuanceAllocator**: Can call the `beforeIssuanceAllocationChange()` hook when registered
+- All existing Rewards Manager roles and permissions remain unchanged
+
+#### 3.4 Backward Compatibility
+
+When issuanceAllocator is unset, Rewards Manager operates unchanged using its existing internal issuance rate. No changes are required to existing participants.
+
+#### 3.5 Configuration
+
+Governance can set/unset the issuanceAllocator address. Rewards Manager must be registered as a self-minting target in the IssuanceAllocator if integration is desired.
+
+### 4. Governance and Monitoring
+
+Protocol governance approves allocation percentages, with regular community reporting and adjustments based on results and feedback. The allocation mechanism can evolve toward the long-term self-balancing vision described in [GIP-0070](0070.md).
+
+#### 4.1 Change Notification System
+
+Before allocation changes, targets are notified via `IIssuanceTarget.beforeIssuanceAllocationChange()` to update internal state to the current block, prepare for the allocation change, and ensure consistency in reward calculations.
+
+#### 4.2 Gas Limit Recovery
+
+The contract includes mechanisms for handling gas limit issues:
+
+- Pause functionality for emergency stops
+- Individual target notification via `notifyTarget()`
+- Force parameters to skip distribution requirements
+- Target removal capabilities for malfunctioning contracts
+
+## Alternatives
+
+Alternatives considered include:
+
+1. **Full Implementation of Self-Balancing Mechanism**: Implementing the complete self-balancing mechanism described in [GIP-0070](0070.md). This was rejected because it would take longer to implement and realize the benefits.
+2. **No Change**: Continuing with the current issuance model. This was rejected as it does not address the needs to improve network economics, enhance incentive alignment, and accelerate innovation.
+3. **Fixed Allocation Percentages**: Establishing fixed percentages for allocations without the flexibility of governance control. This was rejected because it would not allow for adjustments based on changing network needs and priorities.
+4. **Complete Redesign**: Completely redesigning the issuance mechanism from scratch. This was rejected due to the significant development effort, security risks, and potential disruption to the network.
 
 ## Copyright Waiver
 

--- a/gips/0076.md
+++ b/gips/0076.md
@@ -3,7 +3,7 @@ GIP: '0076'
 Title: Issuance Allocator contract to split issuance across distribution targets
 Authors: Rembrandt Kuipers <rembrandt@edgeandnode.com>
 Stage: Draft
-Discussions-To: TBD
+Discussions-To: <https://forum.thegraph.com/t/gip-0076-issuance-allocator-contract-to-split-issuance-across-distribution-targets/6867>
 Category: 'Protocol Logic'
 Depends-On:
   - 'GIP-0070'

--- a/gips/0079.md
+++ b/gips/0079.md
@@ -1,17 +1,22 @@
 ---
-GIP: '0079'
+GIP: "0079"
 Title: Indexer Rewards Eligibility Oracle
+Created: 2023-10-10
 Authors:
   - Rembrandt Kuipers <rembrandt@edgeandnode.com>
   - Samuel Metcalfe <samuel@edgeandnode.com>
 Stage: Draft
-Discussions-To: TBD
-Category: 'Protocol Logic'
+Discussions-To: <https://forum.thegraph.com/t/gip-0079-indexer-rewards-eligibility-oracle/6734>
+Category: "Protocol Logic"
+Depends-On:
+  - "GIP-0086"
 ---
 
 ## Abstract
 
-This GIP proposes the implementation of a Rewards Eligibility Oracle System that enforces minimum service quality requirements for indexers to receive indexing rewards. The system consists of an on-chain Oracle Contract that tracks indexer eligibility and off-chain Oracle Nodes that assess service quality and report eligible indexers to the Contract. This GIP also includes the necessary RewardsManager upgrades to integrate with the Oracle Contract. We anticipate that this mechanism will improve the overall reliability and performance of The Graph network and help the network better compete against other data service providers by aligning indexing incentives with service quality.
+This GIP proposes the implementation of a Rewards Eligibility Oracle System that enforces minimum service quality requirements for indexers to receive indexing rewards. The system consists of an on-chain Oracle Contract that tracks indexer eligibility and off-chain Oracle Nodes that assess service quality and report eligible indexers to the Contract. We anticipate that this mechanism will improve the overall reliability and performance of The Graph network and help the network better compete against other data service providers by aligning indexing incentives with service quality.
+
+Deploying this oracle requires a corresponding upgrade to the Rewards Manager and Subgraph Service, specified in [GIP-0086: Rewards Manager and Subgraph Service Upgrade](0086.md). Approving this GIP implies deploying both the Oracle Contract and the GIP-0086 upgrade, after which governance configures the upgraded Rewards Manager to use the oracle.
 
 ## Contents
 
@@ -30,6 +35,7 @@ This GIP proposes the implementation of a Rewards Eligibility Oracle System that
   - [Roles and Access Control](#roles-and-access-control)
   - [Configuration Parameters](#configuration-parameters)
 - [Off-chain Logic](#off-chain-logic)
+- [Dependencies](#dependencies)
 - [Backward Compatibility](#backward-compatibility)
 - [Risks](#risks)
 - [Copyright Waiver](#copyright-waiver)
@@ -45,7 +51,7 @@ The Rewards Eligibility Oracle System addresses this by making eligibility for I
 This GIP introduces a service quality enforcement system consisting of two main components:
 
 1. **Oracle Contract**: Tracks indexer eligibility based on service quality assessments from Oracle Nodes
-2. **RewardsManager Integration**: Enforces eligibility checks before distributing indexing rewards
+2. **RewardsManager Integration** ([GIP-0086](0086.md)): Enforces eligibility checks before distributing indexing rewards
 
 ### System Flow
 
@@ -117,50 +123,13 @@ interface IRewardsEligibilityOracle {
 
 ### RewardsManager Integration
 
-The RewardsManager is upgraded to optionally enforce service quality before distributing rewards. This integration is backward compatible and only activates when an Oracle Contract is configured.
+The Rewards Manager is upgraded to optionally enforce service quality before distributing rewards. The full specification of the Rewards Manager and Subgraph Service upgrade is in [GIP-0086](0086.md). The integration points relevant to this oracle are:
 
-1. **Optional Integration**: When an Oracle Contract is configured, the RewardsManager checks eligibility before reward distribution.
-2. **Eligibility Verification**: Calls the Oracle Contract's `isAllowed()` function during reward claims.
-3. **Reward Gating**: Only eligible indexers receive rewards; ineligible indexers are denied rewards.
-4. **Backward Compatibility**: When no Oracle Contract is configured, operates exactly as before.
+1. **Optional Integration**: When the Oracle Contract is configured on the Rewards Manager, it checks eligibility before reward distribution. When not configured, the Rewards Manager operates exactly as before.
+2. **Eligibility Verification**: At claim time, the Rewards Manager calls the Oracle Contract's `isEligible()` function. If the indexer is ineligible, rewards are denied and a `RewardsDeniedDueToEligibility` event is emitted.
+3. **Governance Activation**: Governance connects the oracle by calling `setRewardsEligibilityOracle()` on the upgraded Rewards Manager, and can disconnect it at any time by setting the zero address.
 
-#### Service Quality Enforcement
-
-```solidity
-function takeRewards(address _allocationID) external returns (uint256) {
-    // ... existing logic ...
-
-    if (address(rewardsEligibilityOracle) != address(0)) {
-        address indexer = allocations[_allocationID].indexer;
-        if (!rewardsEligibilityOracle.isEligible(indexer)) {
-            emit RewardsDeniedDueToEligibility(indexer, _allocationID);
-            return 0;
-        }
-    }
-
-    // ... continue with reward distribution ...
-}
-```
-
-#### Configuration
-
-```solidity
-function setRewardsEligibilityOracle(address _oracle) external onlyRole(Roles.GOVERNOR) {
-    rewardsEligibilityOracle = IRewardsEligibilityOracle(_oracle);
-    emit RewardsEligibilityOracleSet(_oracle);
-}
-```
-
-#### Events
-
-```solidity
-event RewardsEligibilityOracleSet(address indexed oracle);
-event RewardsDeniedDueToEligibility(address indexed indexer, address indexed allocationID);
-```
-
-#### Interface Requirements
-
-The RewardsManager expects the Oracle Contract to implement:
+The Rewards Manager expects the Oracle Contract to implement:
 
 ```solidity
 interface IRewardsEligibilityOracle {
@@ -195,11 +164,9 @@ Oracle Nodes are expected to regularly update indexer eligibility to ensure the 
 - **ORACLE_ROLE**: Can renew indexer eligibility for rewards via `renewIndexerEligibility()` function
 - **PAUSE_ROLE**: Can pause/unpause contract operations
 
-**RewardsManager Integration:**
+**Rewards Manager** (see [GIP-0086](0086.md)):
 
 - **GOVERNOR_ROLE**: Can set the RewardsEligibilityOracle address via `setRewardsEligibilityOracle()`
-- **Existing roles**: All current RewardsManager roles and permissions remain unchanged
-- **RewardsEligibilityOracle**: Provides read-only eligibility information when configured
 
 ### Configuration Parameters
 
@@ -245,6 +212,10 @@ The Oracle Node logic for determining indexer service quality includes a conserv
 
    Oracle Nodes incorporate multiple failover mechanisms including automatic RPC provider switching, exponential backoff retry logic, and comprehensive health monitoring. All operations generate detailed logs for operational oversight, while historical eligibility data is preserved for a retention period for internal audit in dated directories. These measures ensure continuous Oracle Node operation.
 
+## Dependencies
+
+- [GIP-0086: Rewards Manager and Subgraph Service Upgrade](0086.md) — the Rewards Manager must be upgraded (GIP-0086) before the oracle can be connected. Governance activates the oracle by calling `setRewardsEligibilityOracle()` on the upgraded Rewards Manager after both contracts are deployed.
+
 ## Backward Compatibility
 
 The Rewards Eligibility Oracle System is designed to be backward compatible with the existing Graph Protocol:
@@ -256,7 +227,6 @@ The Rewards Eligibility Oracle System is designed to be backward compatible with
 ## Risks
 
 1. **Oracle Node Centralization**: Authorized Oracle Nodes have significant power over reward distribution. This is mitigated by:
-
    - Multiple Oracle Nodes can be authorized
    - Oracle Node actions are transparent and on-chain
    - Oracle update timeout ensures rewards continue if Oracle Nodes fail

--- a/gips/0086.md
+++ b/gips/0086.md
@@ -1,0 +1,192 @@
+---
+GIP: "0086"
+Title: Rewards Manager and Subgraph Service Upgrade
+Authors: Rembrandt Kuipers <rembrandt@edgeandnode.com>
+Created: 2026-03-06
+Stage: Draft
+Discussions-To: TBD
+Category: "Protocol Logic"
+Depends-On:
+  - "GIP-0066"
+  - "GIP-0068"
+  - "GIP-0076"
+---
+
+## Abstract
+
+This GIP specifies an upgrade to the Rewards Manager and Subgraph Service contracts. The upgrade does not introduce major new protocol mechanisms but makes incremental improvements that enable deployment of the Issuance Allocator ([GIP-0076: Issuance Allocator contract to split issuance across distribution targets](0076.md)) and Rewards Eligibility Oracle ([GIP-0079: Indexer Rewards Eligibility Oracle](0079.md)), and prepare the contracts for future activation of rewards reclaiming, enabling undistributable rewards to be redirected back into the network.
+
+The key improvements are:
+
+1. **Eligibility oracle configuration** — governance can connect an eligibility oracle to the Rewards Manager
+2. **Refined rewards collection** — clearer handling of when rewards are claimed, denied, or deferred
+3. **Rewards reclaiming configuration** — governance can configure addresses to receive undistributable rewards (inactive until configured)
+4. **Improved reward tracking** — better accumulator accounting and new view functions
+
+## Contents <!-- omit in toc -->
+
+- [Abstract](#abstract)
+- [Motivation](#motivation)
+- [Prior Art](#prior-art)
+- [High-Level Description](#high-level-description)
+- [Detailed Specification](#detailed-specification)
+  - [1. Eligibility Oracle Configuration](#1-eligibility-oracle-configuration)
+  - [2. Rewards Collection Behaviour](#2-rewards-collection-behaviour)
+  - [3. Rewards Reclaiming Configuration](#3-rewards-reclaiming-configuration)
+  - [4. Improved Reward Tracking](#4-improved-reward-tracking)
+- [Backward Compatibility](#backward-compatibility)
+- [Dependencies](#dependencies)
+- [Risks and Security Considerations](#risks-and-security-considerations)
+- [Copyright Waiver](#copyright-waiver)
+
+## Motivation
+
+Deploying the Issuance Allocator ([GIP-0076](0076.md)) and Rewards Eligibility Oracle ([GIP-0079](0079.md)) requires corresponding changes in the Rewards Manager and Subgraph Service. These contracts need to:
+
+- Accept an eligibility oracle reference and enforce eligibility at reward claim time
+- Handle the various situations where rewards cannot be distributed with clear, consistent logic
+- Integrate with the Issuance Allocator for issuance rate sourcing
+- Provide better on-chain visibility into reward outcomes
+
+At a high level, the combined effect of these changes is to: allow integration of the Rewards Eligibility Oracle ([GIP-0079](0079.md)) so that indexers who fail to meet service quality thresholds can be denied rewards; allow the issuance rate to be sourced from the Issuance Allocator, enabling governance to direct issuance across multiple targets; improve on-chain visibility of reward outcomes so indexers know exactly why a POI presentation did or did not result in rewards; and prepare the infrastructure for redirecting undistributable rewards to designated contracts rather than silently dropping them.
+
+This upgrade also improves how rewards are tracked and reported, benefiting indexers, delegators, and monitoring tools.
+
+## Prior Art
+
+- [GIP-0066: Introducing Graph Horizon](0066-graph-horizon.md) — the data services protocol framework this upgrade builds on
+- [GIP-0068: Subgraph Service - A subgraph data service in Graph Horizon](0068-subgraph-service.md) — the Subgraph Service, allocation management, and POI handling
+- [GIP-0076: Issuance Allocator contract to split issuance across distribution targets](0076.md) — issuance allocation across multiple targets
+- [GIP-0079: Indexer Rewards Eligibility Oracle](0079.md) — per-indexer eligibility checks for rewards
+
+## High-Level Description
+
+This upgrade refines how rewards flow from issuance to indexers without changing the fundamental reward model. The changes fall into two activation categories:
+
+**Active on deployment** — improvements to rewards accounting, collection handling, and tracking that take effect immediately. These improve how edge cases are handled and provide better visibility into reward outcomes.
+
+**Governance-gated** — capabilities that enable but do not activate changes to protocol issuance or reward flows. The eligibility oracle, issuance allocator integration ([GIP-0076](0076.md)), and reclaim address configuration all require explicit governance action based on separate approvals before they affect rewards.
+
+## Detailed Specification
+
+### 1. Eligibility Oracle Configuration
+
+Governance can set an optional eligibility oracle on the Rewards Manager. When set, the oracle is consulted each time an indexer claims rewards. If the oracle reports the indexer as ineligible, the claim is denied and no rewards are minted.
+
+**How it works for indexers:**
+
+- When presenting a POI, if an eligibility oracle is configured and reports you as ineligible, you receive zero rewards for that claim
+- A `RewardsDeniedDueToEligibility` event is emitted with the denied amount, providing visibility
+- The oracle can be unset by governance at any time to restore the previous behaviour where all indexers can claim
+- See [GIP-0079](0079.md) for fail-safe mechanisms built into the oracle proposal
+
+The eligibility check only applies at the moment of claiming. View functions like `getRewards()` do not reflect eligibility, so the estimated reward amount may differ from the actual claim if the indexer becomes ineligible.
+
+Subgraph denial takes precedence: if a subgraph is on the denylist, the eligibility check is not performed.
+
+### 2. Rewards Collection Behaviour
+
+The upgrade refines how the Subgraph Service handles POI presentation, making the logic clearer and closing some edge cases. When an indexer presents a POI, one of three outcomes occurs:
+
+#### Claim — rewards distributed normally
+
+When conditions are met (valid POI, allocation old enough, subgraph not denied, indexer eligible), rewards are calculated and minted. The allocation's reward tracking is updated. This is the normal path that applies to the majority of POI presentations.
+
+#### Deny — rewards forfeited
+
+When a POI cannot result in a valid reward claim, the rewards are forfeited and the allocation's tracking is updated so those rewards cannot be claimed later. This applies when:
+
+- **Stale POI**: The time since the last POI presentation exceeds the staleness threshold. Indexers are expected to present POIs regularly; stale allocations do not earn rewards.
+- **Zero POI**: A POI of `bytes32(0)` is submitted. This allows indexers to keep an allocation from going stale when no valid POI is available yet; pending rewards are forfeited in exchange.
+- **Ineligible indexer**: The eligibility oracle (if configured) reports the indexer as ineligible.
+- **Allocation close**: When an allocation is closed, any uncollected rewards are forfeited rather than remaining locked.
+
+With reclaim addresses configured (see section 3), forfeited rewards can be redirected to a designated contract instead of being dropped. This enables reclaimed rewards to be redirected back into the network, potentially by funding services that improve network health or increase its value to users.
+
+#### Defer — rewards preserved for later
+
+In some situations, rewards should not be claimed yet but should not be forfeited either. The allocation's tracking is left unchanged, preserving the rewards for a future claim:
+
+- **Allocation too young**: An allocation created in the current epoch cannot claim rewards yet. Rewards are preserved until the next epoch.
+- **Subgraph denied**: If a subgraph is currently on the denylist, existing uncollected rewards are preserved. When the subgraph is later removed from the denylist, those rewards become claimable. Previously, presenting a POI for a denied subgraph still advanced the allocation's reward snapshot, permanently dropping any pre-denial rewards; now the snapshot is left unchanged so those rewards survive the denial period. (New rewards that would have accrued during the denial period are not accumulated — see section 4.)
+
+#### POIPresented event
+
+Every POI presentation emits a `POIPresented` event that includes the outcome (claim, deny, or defer) and the reward amount. This provides on-chain visibility that was previously unavailable — indexers and monitoring tools can see exactly why a given POI presentation did or did not result in rewards.
+
+### 3. Rewards Reclaiming Configuration
+
+Currently, when rewards cannot be distributed, they are silently dropped (never minted). This upgrade adds the ability for governance to configure addresses where undistributable rewards are sent instead.
+
+**Per-condition addresses**: Governance can set a specific address for each type of denial (e.g., stale POI, ineligible indexer, denied subgraph). This allows different handling for different situations.
+
+**Default address**: A fallback address that receives rewards for any condition without a specific address configured.
+
+**Resolution**: When rewards are forfeited, the system checks for a condition-specific address first, then the default address. If neither is configured, rewards are dropped as they are today.
+
+**Not activated by this GIP**: This upgrade enables the reclaim configuration capability, but activation (actually setting reclaim addresses) is a separate governance decision. Until addresses are configured, forfeited rewards continue to be dropped as they are today.
+
+### 4. Improved Reward Tracking
+
+#### Accumulator improvements
+
+The reward accumulators that track how rewards flow from issuance to subgraphs to allocations are refined:
+
+- **Denied subgraphs**: When a subgraph is placed on the denylist, its accumulators are frozen. Issuance that would have flowed to the denied subgraph no longer accumulates there. Previously, rewards continued accumulating during denial periods but could never be claimed, creating a permanent gap between issued and distributed tokens. Pre-denial uncollected rewards are preserved and become claimable if the subgraph is later un-denied.
+
+- **Zero global signal**: Periods when there is no curation signal across the network are now detected. Issuance during these periods is tracked separately rather than silently lost.
+
+- **Below-minimum signal**: Subgraphs with curation signal below the minimum threshold are tracked. Rewards that would flow to these subgraphs are identified rather than silently excluded.
+
+- **No allocations**: When a subgraph has curation signal but no indexer allocations, rewards that accumulate at the subgraph level with no recipient are now tracked.
+
+#### New view functions
+
+| Function                         | Description                                                                                     |
+| -------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `getAllocatedIssuancePerBlock()` | Effective issuance rate — from the Issuance Allocator if configured, otherwise the legacy value |
+| `getRawIssuancePerBlock()`       | The legacy issuance storage value, for debugging allocator configuration                        |
+| `getRewardsEligibilityOracle()`  | Current eligibility oracle address (zero if not configured)                                     |
+| `getReclaimAddress(condition)`   | Reclaim address for a specific condition (zero if not configured)                               |
+| `getDefaultReclaimAddress()`     | Default reclaim address (zero if not configured)                                                |
+
+#### Changes to existing view functions
+
+- `getAccRewardsForSubgraph()` and `getAccRewardsPerAllocatedToken()` now reflect accumulator freezing for non-claimable subgraphs. Previously these values always increased; they now freeze when the subgraph is denied, below minimum signal, or has no allocations.
+
+- `getRewards()` returns a frozen value for allocations on non-claimable subgraphs. Note that eligibility is not reflected in this view — it is only checked at actual claim time.
+
+## Backward Compatibility
+
+The upgrade improves rewards accounting and collection handling, which takes effect on deployment. These changes refine how edge cases are handled — for example, denied subgraphs now freeze accumulators rather than accumulating unclaimable rewards.
+
+Features that affect protocol issuance or reward flows — the eligibility oracle, issuance allocator, and reclaim addresses — are enabled but not activated. They require separate governance action and do not change rewards behaviour until configured.
+
+Callers of view functions that rely on accumulators always increasing should be aware that accumulators now freeze for non-claimable subgraphs.
+
+## Dependencies
+
+- [GIP-0076: Issuance Allocator contract to split issuance across distribution targets](0076.md) — the Rewards Manager sources its issuance rate from the allocator when configured
+
+**Related:**
+
+- [GIP-0079: Indexer Rewards Eligibility Oracle](0079.md) — the oracle contract that the Rewards Manager consults for eligibility checks. The eligibility oracle integration is governance-gated and does not require GIP-0079 to be deployed for GIP-0086 to be deployed.
+
+## Risks and Security Considerations
+
+1. **Oracle availability**: If the eligibility oracle reverts or becomes unavailable, reward claims will revert for all indexers. The oracle includes a timeout mechanism ([GIP-0079](0079.md)) that makes all indexers eligible if the oracle is not updated within a configurable period, providing a safety fallback.
+
+2. **Oracle misconfiguration**: Inappropriate configuration parameters on the oracle — such as overly strict thresholds or incorrect freshness windows — could cause it to deny eligibility more broadly than intended. Because eligibility is evaluated at claim time, the impact might not be apparent until indexers attempt to collect. Mitigations:
+   - The oracle's built-in **timeout mechanism** ([GIP-0079](0079.md)) ensures that if oracle data becomes stale, all subgraphs are treated as eligible, so a failure to update is self-correcting.
+   - The oracle can be **unset by governance** (set to the zero address) to bypass it entirely and restore previous behaviour immediately.
+   - Once corrected, previously denied rewards are not lost — accumulators resume from their frozen snapshots, so indexers collect the full amount they would have earned.
+
+3. **Rewards lost to transient ineligibility**: Eligibility is evaluated at claim time. An indexer who claims during a brief period of ineligibility forfeits those rewards permanently, even though waiting and claiming later (after regaining eligibility) would have preserved them. An eligibility dashboard is provided so indexers can monitor their status before claiming, and additional operational tooling is under consideration.
+
+4. **Broad ineligibility event**: A configuration change or systemic issue could cause many indexers to become ineligible simultaneously. This is mitigated by initially setting very relaxed eligibility criteria, the eligibility dashboard, proactive community communication, and direct assistance to potentially impacted indexers to help them resolve service issues before stricter thresholds are applied.
+
+5. **Accumulator view changes**: External systems reading accumulator values that expect them to always increase will see frozen values for non-claimable subgraphs. This is correct behaviour but might require updates to monitoring or analytics tools.
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/gips/0086.md
+++ b/gips/0086.md
@@ -4,7 +4,7 @@ Title: Rewards Manager and Subgraph Service Upgrade
 Authors: Rembrandt Kuipers <rembrandt@edgeandnode.com>
 Created: 2026-03-06
 Stage: Draft
-Discussions-To: TBD
+Discussions-To: <https://forum.thegraph.com/t/gip-0086-rewards-manager-and-subgraph-service-upgrade/6868>
 Category: "Protocol Logic"
 Depends-On:
   - "GIP-0066"

--- a/gips/0087.md
+++ b/gips/0087.md
@@ -4,7 +4,7 @@ Title: On-Chain Indexing Agreements
 Authors: Rembrandt Kuipers <rembrandt@edgeandnode.com>
 Created: 2026-03-06
 Stage: Draft
-Discussions-To: TBD
+Discussions-To: <https://forum.thegraph.com/t/on-chain-indexing-agreements-and-issuance-allocation-gip-0087-gip-0088/6869>
 Category: "Protocol Logic"
 Depends-On:
   - "GIP-0066"

--- a/gips/0087.md
+++ b/gips/0087.md
@@ -1,0 +1,180 @@
+---
+GIP: "0087"
+Title: On-Chain Indexing Agreements
+Authors: Rembrandt Kuipers <rembrandt@edgeandnode.com>
+Created: 2026-03-06
+Stage: Draft
+Discussions-To: TBD
+Category: "Protocol Logic"
+Depends-On:
+  - "GIP-0066"
+  - "GIP-0068"
+  - "GIP-0081"
+  - "GIP-0076"
+---
+
+## Abstract
+
+This GIP specifies the on-chain implementation of indexing payments as described in [GIP-0081: A New Proposal for Indexing Payments](0081.md). Where GIP-0081 defined the indexing agreements model and an off-chain mechanism, this GIP adds on-chain mechanisms to offer and accept agreements and enables on-chain escrow management using Graph Horizon primitives.
+
+The core addition is the **on-chain indexing agreement model**: a contract-managed system where agreements between payers and indexers are offered, accepted, and settled through smart contracts, with on-chain escrow funding from protocol issuance. This provides an alternative to the signature-based trust model described in GIP-0081, using contract-based authorization.
+
+## Contents <!-- omit in toc -->
+
+- [Abstract](#abstract)
+- [Motivation](#motivation)
+- [Prior Art](#prior-art)
+- [High-Level Description](#high-level-description)
+  - [How It Works for Indexers](#how-it-works-for-indexers)
+  - [How It Works for Payers](#how-it-works-for-payers)
+- [Detailed Specification](#detailed-specification)
+  - [1. On-Chain Agreement Lifecycle](#1-on-chain-agreement-lifecycle)
+  - [2. Contract-Based Authorization](#2-contract-based-authorization)
+  - [3. Automated Escrow Funding](#3-automated-escrow-funding)
+  - [4. Escrow Management Improvements](#4-escrow-management-improvements)
+  - [5. Subgraph Service Integration](#5-subgraph-service-integration)
+- [Backward Compatibility](#backward-compatibility)
+- [Dependencies](#dependencies)
+- [Risks and Security Considerations](#risks-and-security-considerations)
+- [Copyright Waiver](#copyright-waiver)
+
+## Motivation
+
+[GIP-0081](0081.md) introduced indexing payments — a mechanism for payers (typically gateways) to incentivize indexers to serve specific subgraphs through signed agreements. Indexing rewards distribute protocol issuance based on curation signal — consumers can curate on subgraphs to attract indexers, but the amount of signal required and the indexing response it will produce are unpredictable, and the coarse matching of supply to demand through curation creates inefficiency for both indexers and consumers. Indexing agreements address this by letting payers directly fund the indexing they need at market-determined prices — indexers advertise their prices, payers select indexers and offer terms, and the market adjusts through this competitive process.
+
+GIP-0081 specified an off-chain mechanism with payment vouchers processed as query fees. That mechanism has weaker trust guarantees:
+
+- Indexers must trust that the gateway will issue payment vouchers after work is done
+- Gateways must trust that indexers report correct work amounts, with no slashing recourse
+- Escrow management requires off-chain coordination
+
+Adding on-chain agreement and escrow mechanisms addresses these limitations.
+
+Additionally, this GIP introduces the ability to fund indexing payment escrow from protocol issuance via the Issuance Allocator ([GIP-0076: Issuance Allocator contract to split issuance across distribution targets](0076.md)), enabling the protocol to directly fund indexing work through explicit agreements, complementing the existing value flows to indexers — indexing rewards (protocol issuance distributed based on curation signal) and query fees.
+
+## Prior Art
+
+- [GIP-0081: A New Proposal for Indexing Payments](0081.md) — the indexing agreements model and off-chain mechanism
+- [GIP-0066: Introducing Graph Horizon](0066-graph-horizon.md) — the payments protocol, escrow, and data service framework
+- [GIP-0068: Subgraph Service - A subgraph data service in Graph Horizon](0068-subgraph-service.md) — the Subgraph Service and allocation management
+- [GIP-0076: Issuance Allocator contract to split issuance across distribution targets](0076.md) — issuance allocation to multiple targets
+
+## High-Level Description
+
+### How It Works for Indexers
+
+1. **Receive an offer**: A payer (gateway or protocol-managed agreement manager) creates an on-chain agreement offer for a specific subgraph. The offer specifies payment terms — maximum amounts, price per unit of work, collection frequency, and duration.
+
+2. **Accept the agreement**: Your indexer agent software evaluates the offer against your configured criteria and, if acceptable, accepts the agreement through the Subgraph Service by associating it with an allocation. Acceptance is verified by the agreement manager contract — no signatures from the payer are needed after the initial offer.
+
+3. **Do the work and collect**: Index the subgraph and periodically collect payment by presenting a POI through the Subgraph Service. The Subgraph Service posts your POI (which can be used in subsequent disputes), calculates payment based on the agreed pricing, and initiates collection from the payer's escrow. Payment is guaranteed up to the escrowed amount — you don't need to trust the payer.
+
+4. **Agreement ends**: Agreements have a defined end date. Either party can cancel early — payer cancellation triggers a final collection window so you can collect for all work done, while indexer cancellation takes effect immediately. After cancellation or expiry, the agreement is cleaned up.
+
+### How It Works for Payers
+
+1. **Offer agreements**: Create agreement offers specifying the subgraph, payment terms, and deadline for acceptance. Escrow is funded to cover the worst-case payment amount.
+
+2. **Monitor and manage**: Agreements are collected on a recurring basis. After each collection, escrow is automatically reconciled — topped up if needed, excess thawed for withdrawal. You can cancel agreements that no longer meet your needs.
+
+3. **Automated funding** (for protocol-managed agreements): The Recurring Agreement Manager receives minted GRT from the Issuance Allocator and automatically maintains escrow balances across all managed agreements. Individual agreement management is handled by authorized operators.
+
+## Detailed Specification
+
+### 1. On-Chain Agreement Lifecycle
+
+Agreements follow a defined lifecycle managed entirely on-chain:
+
+**Offer**: The payer creates an agreement offer specifying:
+
+- The subgraph to be indexed
+- Additional allowance for the first collection (e.g., to cover initial sync costs)
+- Maximum ongoing payment rate (tokens per second)
+- Maximum time between collections
+- Price per unit of work
+- Acceptance deadline and agreement end date
+
+The offer is recorded on-chain and escrow is deposited to cover the maximum possible first collection.
+
+**Accept**: An indexer accepts the offer through the Subgraph Service, associating it with an allocation. The agreement manager contract verifies the acceptance via a callback — no separate signature exchange is needed. Once accepted, the agreement is active and the indexer can begin collecting.
+
+**Collect**: The indexer periodically presents a POI and collects payment through the Subgraph Service. The collection flow passes through the Recurring Collector (from Graph Horizon), which enforces agreement terms — maximum amounts, collection frequency limits, and agreement start/end date enforcement. After collection, the agreement manager automatically reconciles escrow for the next period.
+
+**Cancel**: Either party can cancel:
+
+- Payer cancellation freezes the payment window at the cancellation time, but allows the indexer a final collection for work done up to that point
+- Indexer cancellation takes effect immediately with no further obligations
+
+**Remove**: After all collection windows have expired and the agreement has no remaining obligations, it can be cleaned up by anyone (permissionless).
+
+### 2. Contract-Based Authorization
+
+GIP-0081 specified ECDSA signatures for agreement acceptance and updates — the payer signs a voucher, the indexer posts it on-chain.
+
+This GIP introduces a **contract approver model** as an alternative to signature-based authorization. The agreement manager contract implements an approval callback that the Recurring Collector invokes when an indexer accepts or an agreement is updated. The contract verifies the operation against its own state (is this a valid offer? is it still within deadline?) without requiring any additional signatures.
+
+### 3. Automated Escrow Funding
+
+The **Recurring Agreement Manager** is a new contract that automates escrow management for protocol-funded indexing agreements. It serves as both an issuance target (receiving minted GRT from the Issuance Allocator) and an agreement owner (managing the lifecycle of indexing agreements).
+
+**Receiving issuance**: The Recurring Agreement Manager implements the `IIssuanceTarget` interface from [GIP-0076](0076.md). When configured as an allocation target in the Issuance Allocator, it receives minted GRT at a governance-configured rate per block.
+
+**Maintaining escrow**: For each active agreement, the manager maintains sufficient escrow to cover the maximum next collection. One escrow account per (collector, provider) pair covers all agreements for that pair, reducing gas costs. The manager tracks the sum of maximum claims across all agreements and deposits or withdraws to maintain coverage.
+
+**Escrow modes**: The manager supports three operational modes that control how aggressively escrow is pre-deposited:
+
+- **Full**: Pre-deposits worst-case amounts for all active agreements. This is the default and provides maximum payment certainty for indexers.
+- **OnDemand**: Maintains thaw ceilings at the worst-case level but does not pre-deposit. Deposits happen when needed.
+- **JustInTime**: Pure just-in-time deposits at collection time. Minimizes locked capital but relies on available balance at collection time.
+
+The system gracefully degrades from higher to lower modes when the available balance is insufficient, allowing operation to continue at lower levels of funding.
+
+**Automatic reconciliation**: After each collection, the Recurring Collector notifies the agreement manager, which automatically reconciles the escrow — updating tracked amounts, depositing shortfalls, or thawing excess. Manual reconciliation is available as a fallback and can be called by anyone.
+
+### 4. Escrow Management Improvements
+
+The PaymentsEscrow contract (from [GIP-0066: Introducing Graph Horizon](0066-graph-horizon.md)) gains an **adjustThaw** capability. Previously, modifying a pending thaw required cancelling and restarting, which reset the thaw timer. `adjustThaw` allows:
+
+- Reducing a thaw amount without resetting the timer
+- Increasing a thaw amount (which may reset the timer, configurable by the caller)
+- Capping thaw amounts at the available balance
+
+This enables the Recurring Agreement Manager to efficiently manage escrow across many agreements — reducing thaw when new agreements are added, or increasing thaw when agreements end — without unnecessarily resetting thaw timers that protect indexers.
+
+### 5. Subgraph Service Integration
+
+The Subgraph Service gains an `IDataServiceAgreements` interface that enables it to participate in the agreement lifecycle:
+
+- **Accept agreements**: Indexers accept agreements through the Subgraph Service, which associates them with allocations and routes acceptance to the agreement manager
+- **Collect against agreements**: POI presentation for agreement-based allocations triggers collection through the Recurring Collector
+- **Cancel agreements**: Indexers can cancel agreements through the Subgraph Service
+
+This integrates indexing agreements into the existing allocation and POI infrastructure, maintaining consistency with how the Subgraph Service manages indexer work.
+
+## Backward Compatibility
+
+This GIP introduces new contracts and interfaces. Existing protocol participants are not affected:
+
+- The Recurring Agreement Manager is a new contract deployment, not an upgrade to existing contracts
+- The SubgraphService gains a new interface for agreement operations without changing existing allocation or POI behaviour
+- The PaymentsEscrow `adjustThaw` capability is additive — existing thaw operations continue to work as before
+- Indexers are not required to participate in indexing agreements; existing allocation and reward mechanisms are unchanged
+
+## Dependencies
+
+- [GIP-0066: Introducing Graph Horizon](0066-graph-horizon.md) — PaymentsEscrow, GraphPayments, and the Recurring Collector
+- [GIP-0068: Subgraph Service - A subgraph data service in Graph Horizon](0068-subgraph-service.md) — allocation management and POI handling
+- [GIP-0076: Issuance Allocator contract to split issuance across distribution targets](0076.md) — issuance allocation to the Recurring Agreement Manager
+- [GIP-0081: A New Proposal for Indexing Payments](0081.md) — the agreements model that this GIP implements on-chain
+
+## Risks and Security Considerations
+
+1. **Escrow underfunding**: If the Recurring Agreement Manager's issuance allocation is insufficient to cover all active agreements, the system degrades to just-in-time deposits. In the worst case, collections may fail if no balance is available at collection time. Mitigation: monitoring of `totalEscrowDeficit` and governance adjustment of issuance allocation. The escrow mode degradation ensures the system fails gracefully rather than blocking entirely.
+
+2. **Agreement manager compromise**: The Recurring Agreement Manager controls significant GRT flows. A compromised operator role could create agreements that extract funds. Mitigation: role-based access control with separate governor, operator, and agreement manager roles. The governor role is expected to be held by governance (multisig).
+
+3. **Issuance dependency**: Protocol-funded agreements depend on the Issuance Allocator continuing to allocate tokens. If the allocation is reduced or removed by governance, existing agreements may become underfunded. Mitigation: the escrow mode degradation system ensures graceful handling, and governance changes to issuance allocation should account for existing agreement obligations.
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/gips/0088.md
+++ b/gips/0088.md
@@ -1,0 +1,121 @@
+---
+GIP: "0088"
+Title: Issuance Allocator Deployment and Indexing Payments Configuration
+Authors: Rembrandt Kuipers <rembrandt@edgeandnode.com>
+Created: 2026-03-06
+Stage: Draft
+Discussions-To: TBD
+Category: "Protocol Logic"
+Depends-On:
+  - "GIP-0076"
+  - "GIP-0086"
+  - "GIP-0087"
+---
+
+## Abstract
+
+This GIP specifies the deployment and configuration of the Issuance Allocator ([GIP-0076: Issuance Allocator contract to split issuance across distribution targets](0076.md)), connecting it to the upgraded Rewards Manager ([GIP-0086: Rewards Manager and Subgraph Service Upgrade](0086.md)) and establishing an issuance allocation for the Recurring Agreement Manager ([GIP-0087: On-Chain Indexing Agreements](0087.md)).
+
+The Issuance Allocator is a governance-controlled contract that manages how token issuance is distributed across protocol components. This GIP covers three sequential steps:
+
+1. **Deploy the Issuance Allocator** — deploy and configure the contract, replicating the current issuance rate
+2. **Connect the Rewards Manager** — configure the upgraded Rewards Manager to source its issuance rate from the allocator
+3. **Allocate issuance to the Recurring Agreement Manager** — add the agreement manager as an issuance target, enabling protocol-funded indexing agreements
+
+## Contents <!-- omit in toc -->
+
+- [Abstract](#abstract)
+- [Motivation](#motivation)
+- [Prior Art](#prior-art)
+- [High-Level Description](#high-level-description)
+- [Detailed Specification](#detailed-specification)
+  - [1. Issuance Allocator Deployment](#1-issuance-allocator-deployment)
+  - [2. Rewards Manager Integration](#2-rewards-manager-integration)
+  - [3. Recurring Agreement Manager Allocation](#3-recurring-agreement-manager-allocation)
+  - [4. Default Target Safety Net](#4-default-target-safety-net)
+- [Backward Compatibility](#backward-compatibility)
+- [Dependencies](#dependencies)
+- [Risks and Security Considerations](#risks-and-security-considerations)
+- [Copyright Waiver](#copyright-waiver)
+
+## Motivation
+
+The Issuance Allocator ([GIP-0076](0076.md)) enables the protocol to split token issuance across multiple targets — today all issuance goes to the Rewards Manager for indexer rewards, but the protocol needs to also fund indexing agreements through the Recurring Agreement Manager ([GIP-0087](0087.md)).
+
+Without the allocator, the Recurring Agreement Manager cannot receive minted GRT from issuance and protocol-funded indexing agreements cannot operate.
+
+## Prior Art
+
+- [GIP-0076: Issuance Allocator contract to split issuance across distribution targets](0076.md) — the contract being deployed
+- [GIP-0086: Rewards Manager and Subgraph Service Upgrade](0086.md) — the Rewards Manager upgrade that adds `setIssuanceAllocator()` integration
+- [GIP-0087: On-Chain Indexing Agreements](0087.md) — the Recurring Agreement Manager that will receive issuance
+
+## High-Level Description
+
+Today, the Rewards Manager mints GRT directly based on an issuance rate configured in its own storage. The Issuance Allocator replaces this with a governance-managed allocation system where the total issuance rate is split across targets.
+
+**Phase 1 — Deploy and replicate**: The Issuance Allocator is deployed with the same issuance rate the Rewards Manager currently uses. The Rewards Manager is assigned 100% of issuance as a self-minting target (it continues to mint its own tokens). At this point, nothing changes for indexers or delegators — the same amount of GRT is issued at the same rate.
+
+**Phase 2 — Connect**: The upgraded Rewards Manager is configured to source its issuance rate from the allocator instead of its own storage. The allocator is granted the minter role on GraphToken. The Rewards Manager still receives 100% of issuance and continues to self-mint. There is no change in issuance behaviour.
+
+**Phase 3 — Split**: Governance adds the Recurring Agreement Manager as a new issuance target, initially allocating 6 GRT per block (~5% of issuance) to fund indexing agreements. The Rewards Manager's allocation is reduced accordingly. The allocator mints GRT directly to the agreement manager at the configured rate. The total issuance rate remains unchanged — it is split between two targets rather than going entirely to one.
+
+## Detailed Specification
+
+### 1. Issuance Allocator Deployment
+
+The Issuance Allocator ([GIP-0076](0076.md)) is deployed as a new contract under governance control. It is configured to replicate the current issuance rate from the Rewards Manager, with the Rewards Manager as the sole target receiving 100% of issuance.
+
+The Rewards Manager is a **self-minting** target — the allocator tracks its allocation but the Rewards Manager continues to mint tokens itself. This means the allocator can be deployed and configured without any change to how issuance works. The deployment is a no-op from the perspective of indexers, delegators, and the broader protocol.
+
+### 2. Rewards Manager Integration
+
+Governance connects the upgraded Rewards Manager ([GIP-0086](0086.md)) to the allocator. From this point, the Rewards Manager sources its issuance rate from the allocator rather than its own storage. The allocator is also granted the minter role on GraphToken, which it needs to mint tokens directly to future allocator-minting targets.
+
+At this stage the Rewards Manager still receives 100% of issuance and continues to self-mint. There is no change in issuance behaviour.
+
+### 3. Recurring Agreement Manager Allocation
+
+Governance adds the Recurring Agreement Manager ([GIP-0087](0087.md)) as an **allocator-minting** target — the allocator calculates and mints GRT directly to it. The Rewards Manager's self-minting allocation is reduced by the corresponding amount.
+
+**Proposed initial allocation: 6 GRT per block (~5% of current issuance).** Based on current GRT price and demand forecasts, this is expected to comfortably cover what is initially required to begin migrating indexing off the upgrade indexer. The full cost of indexing has been estimated at approximately $130k/month, which at current prices would require roughly 10% of issuance. The initial 5% allocation provides headroom for the early ramp-up period while keeping the impact on staking rewards modest.
+
+This allocation may need to increase — potentially to ~12 GRT per block (~10% of issuance) — as agreement volume grows. The exact trajectory depends on several highly variable factors: GRT price, the pace of migration from the upgrade indexer, the escrow cycle (which creates an early spike in demand to fill buffers that subsequently settles), and evolving requirements around deployment coverage and replication.
+
+**Future self-balancing**: This initial deployment uses a fixed governance-configured allocation. We intend to replace this with a self-balancing mechanism that adjusts the allocation to meet demand without ongoing governance intervention. Gaining operational experience with the fixed allocation will inform the design of that mechanism. The goal is for the protocol to maintain balanced operation — avoiding both excess accumulation of unused GRT and underfunding — without requiring regular governance action.
+
+The total issuance rate does not change — it is redistributed. With 6 GRT per block allocated to the agreement manager, the Rewards Manager's self-minting allocation decreases from ~120.73 to ~114.73 GRT per block.
+
+The allocator maintains the invariant that the sum of all target allocations equals `issuancePerBlock`. Governance cannot over-allocate — the available budget for a new target is limited to the currently unallocated amount (held by the default target).
+
+### 4. Default Target Safety Net
+
+A DirectAllocation contract under governance control is set as the allocator's default target during deployment. The default target is intended to receive no issuance under normal operation — all issuance should be fully allocated to named targets (Rewards Manager, Recurring Agreement Manager).
+
+However, if a future configuration change is not made atomically (e.g., removing a target before reassigning its allocation), the default target captures the temporarily unallocated issuance rather than leaving it unminted. Only the governance multisig can withdraw from the DirectAllocation. It is intended to remain unused but provides a safety net against accounting gaps during reconfiguration.
+
+## Backward Compatibility
+
+This deployment does not change the total issuance rate or the reward model. During phases 1 and 2, indexers and delegators see no change — the same GRT is issued at the same rate through the same Rewards Manager.
+
+When the agreement manager allocation is configured (phase 3), the Rewards Manager's allocation decreases by the amount redirected to agreements. Indexer rewards from issuance decrease proportionally. This is an intentional policy change — governance is directing a portion of issuance to fund indexing agreements rather than pure staking rewards.
+
+## Dependencies
+
+- [GIP-0076: Issuance Allocator contract to split issuance across distribution targets](0076.md) — the contract specification
+- [GIP-0086: Rewards Manager and Subgraph Service Upgrade](0086.md) — the Rewards Manager must be upgraded before integration
+- [GIP-0087: On-Chain Indexing Agreements](0087.md) — the Recurring Agreement Manager must be deployed before allocation
+
+## Risks and Security Considerations
+
+1. **Issuance rate mismatch during migration**: If the rate set on the allocator does not exactly match the Rewards Manager's current rate, there will be a discontinuity in issuance. Mitigation: the deployment procedure reads the rate directly from the Rewards Manager and verifies they match before governance transfer.
+
+2. **Deployment sequencing**: The deployment involves multiple contracts and configuration steps that must be executed in the correct order — deploying the allocator, verifying configuration, granting the minter role, and connecting the Rewards Manager. Incorrect sequencing could lead to misconfigured minting or mismatched issuance rates. Mitigation: a detailed deployment procedure with verification steps at each stage.
+
+3. **Allocation rebalancing impact**: Redirecting issuance from the Rewards Manager to the agreement manager reduces staking rewards while increasing agreement-based payments — both flow to indexers, but through different mechanisms with different distribution characteristics. If the shift is too large relative to agreement volume, excess GRT may accumulate in the agreement manager's escrow rather than reaching indexers promptly. Mitigation: governance controls the allocation rate and can adjust it incrementally. The allocation change is transparent and subject to governance approval.
+
+4. **Pause propagation**: Pausing the Issuance Allocator stops allocator-minting (tokens are not minted to the agreement manager) but self-minting targets like the Rewards Manager continue to track issuance via accumulation. When unpaused, the allocator applies current rates retroactively to the undistributed period. Mitigation: pause functionality is controlled by a dedicated pause guardian, and the accumulation model ensures accounting integrity across pause/unpause transitions.
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/gips/0088.md
+++ b/gips/0088.md
@@ -4,7 +4,7 @@ Title: Issuance Allocator Deployment and Indexing Payments Configuration
 Authors: Rembrandt Kuipers <rembrandt@edgeandnode.com>
 Created: 2026-03-06
 Stage: Draft
-Discussions-To: TBD
+Discussions-To: <https://forum.thegraph.com/t/on-chain-indexing-agreements-and-issuance-allocation-gip-0087-gip-0088/6869>
 Category: "Protocol Logic"
 Depends-On:
   - "GIP-0076"


### PR DESCRIPTION
Delays in merging to main has created broken links between GIPs, which this combined PR helps alleviate.

This PR combines previously separate PR related to Rewards Eligibilyt Oracle and Indexing Payments.

- [GIP-0076](/RembrandtK/graph-improvement-proposals/tree/gips-reo-ip-combined/gips/0076.md) introduces a simple Issuance Allocator contract. In this iteration the Issuance Allocator operates based on fixed proportions, while future iterations can introduce self-balancing of issuance as outlined in GIP-0070.
- [GIP-0079](/RembrandtK/graph-improvement-proposals/tree/gips-reo-ip-combined/gips/0079.md) is updated to refer to GIP-0086.
- [GIP-0086](/RembrandtK/graph-improvement-proposals/tree/gips-reo-ip-combined/gips/0086.md) specifies an upgrade to the Rewards Manager and Subgraph Service contracts.
- [GIP-0087](/RembrandtK/graph-improvement-proposals/tree/gips-reo-ip-combined/gips/0087.md) specifies the on-chain implementation of indexing payments.
- [GIP-0088](/RembrandtK/graph-improvement-proposals/tree/gips-reo-ip-combined/gips/0088.md) specifies the deployment and configuration of the Issuance Allocator, connecting it to the upgraded Rewards Manager and establishing an issuance allocation for the Recurring Agreement Manager.

All cross-references between GIPs use relative paths (e.g. `0086.md`, `0066-graph-horizon.md`) so that links work both before and after merging.